### PR TITLE
Syntax with <type:key> for route parameters.

### DIFF
--- a/app/app.vala
+++ b/app/app.vala
@@ -92,8 +92,9 @@ app.scope("admin", (adm) => {
 	});
 });
 
-app.get("hello/:id", (req, res) => {
-	res.append("yay");
+app.get("hello/<id>", (req, res) => {
+	res.mime = "text/plain";
+	res.append("");
 	res.append(req.params["id"]);
 	res.send();
 });


### PR DESCRIPTION
This will allow us to type our route parameters by using specific regex.

Right now, there is no type support, but I think we could add it using a HashMap of type => Regex so that any type could be registered in the matching process.
