### PR TITLE
Using default handler for before and after request signals.

### DIFF
--- a/src/router.vala
+++ b/src/router.vala
@@ -10,19 +10,19 @@ namespace Valum {
 		private string[] _scope;
 
 		// signal called before a request execution starts
-		public signal void before_request (Request req, Response res);
+		public virtual signal void before_request (Request req, Response res) {
+			res.status = 200;
+			res.mime   = "text/html";
+		}
 
 		// signal called after a request has executed
-		public signal void after_request (Request req, Response res);
+		public virtual signal void after_request (Request req, Response res) {
+			res.message.response_body.complete ();
+		}
 
 		public delegate void NestedRouter(Valum.Router app);
 
 		public Router() {
-
-			// complete the response body
-			this.after_request.connect((req, res) => {
-				res.message.response_body.complete ();
-			});
 
 #if (BENCHMARK)
 			var timer  = new Timer();
@@ -37,12 +37,6 @@ namespace Valum {
 				res.headers.append("X-Runtime", "%8.3fms".printf(elapsed * 1000));
 			});
 #endif
-
-			// initialize the Response object
-			this.before_request.connect((req, res) => {
-				res.status = 200;
-				res.mime = "text/html";
-			});
 		}
 
 		//


### PR DESCRIPTION
In the before_request default handler, the Response object is
initialized. This way, the Response object is still uninitialized for
connected handlers.

In the after_request default handler, the Response body is completed.
This way, anything registered after_request may still edit the body
before it gets completed.

For both, handlers can be connected after using connect_after.
