### PR TITLE
Uses a delegator to define VSGI.Application.

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -44,7 +44,7 @@ It is also to use the `FastCGIServer`, but it needs a specific setup that is
 covered in the [FastCGI section](server/fastcgi.md) of the documentation.
 
 ```java
-new SoupServer (app, 3003).run ();
+new SoupServer (app.handler, 3003).run ();
 ```
 It is also possible to use the [FastCGI server](server/fastcgi.md)
 implementation, but it needs a specific setup and a web server supporting the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ app.get("", (req, res) => {
     writer.put_string ("Hello world!");
 });
 
-new SoupServer (app, 3003).run ();
+new SoupServer (app.handler, 3003).run ();
 ```
 
 ```

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -283,4 +283,4 @@ app.handle.connect_after ((req, res) => {
 	}
 });
 
-new VSGI.SoupServer (app, 3003).run ();
+new VSGI.SoupServer (app.handler, 3003).run ();

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -38,5 +38,5 @@ public static int main (string[] args) {
 		writer.put_string ("404 - Not found");
 	});
 
-	return new VSGI.FastCGIServer (app).run (args);
+	return new VSGI.FastCGIServer (app.handler).run (args);
 }

--- a/src/router.vala
+++ b/src/router.vala
@@ -6,11 +6,11 @@ namespace Valum {
 	/**
 	 * @since 0.0.1
 	 */
-	public class Router : GLib.Object, VSGI.Application {
+	public class Router : GLib.Object {
 
 		/**
 		 * Registered types.
-         *
+		 *
 		 * @since 0.1
 		 */
 		public HashTable<string, Regex> types = new HashTable<string, Regex> (str_hash, str_equal);
@@ -129,7 +129,7 @@ namespace Valum {
 
 		/**
 		 * Bind a callback with a custom method.
-         *
+		 *
 		 * Useful if you need to support a non-standard HTTP method, otherwise you
 		 * should use the predefined methods.
 		 *
@@ -155,10 +155,10 @@ namespace Valum {
 
 		/**
 		 * Bind a callback with a custom method and regular expression.
-         *
+		 *
 		 * It is recommended to declare the Regex using the RegexCompileFlags.OPTIMIZE
 		 * flag as it will be used *very* often during the application process.
-         *
+		 *
 		 * @since 0.1
 		 *
 		 * @param method HTTP method
@@ -222,7 +222,7 @@ namespace Valum {
 		 * @param req request being handled.
 		 * @param res response being transmitted to the request client.
 		 */
-		public void handle (Request req, Response res) {
+		public virtual signal void handle (Request req, Response res) {
 			try {
 				// ensure at least one route has been declared with that method
 				if (this.routes.contains(req.method)) {
@@ -245,6 +245,22 @@ namespace Valum {
 			} catch (ServerError e) {
 				res.status = e.code;
 			}
+		}
+
+		/**
+		 * Provides VSGI.Application implementation so that a Router can be combined
+		 * with a {@link VSGI.Server} implementation.
+		 *
+		 * Typical run code should look like
+		 *
+		 * new SoupServer (app.handler).run (args);
+		 *
+		 * @since 0.1
+		 *
+		 * @see VSGI.Application
+		 */
+		public void handler (Request req, Response res) {
+			this.handle (req, res);
 		}
 	}
 }

--- a/src/vsgi/application.vala
+++ b/src/vsgi/application.vala
@@ -11,32 +11,22 @@
 namespace VSGI {
 
 	/**
-	 * @since 0.1
-	 */
-	public const string APP_NAME = "VSGI";
-
-	/**
-	 * Application that handles Request and produce Response.
+	 * VSGI application handling a {@link Request} and producing a
+	 * {@link Response}.
+	 *
+	 * A working application is easily defined when combined with a
+	 * {@link Server} implementation.
+	 *
+	 * new SoupServer ((req, res) => {
+	 *     res.write ("Hello world!".data);
+	 * });
 	 *
 	 * @since 0.1
+	 *
+	 * @param Request  req request providen to the application by a
+	 *                     VSGI.Server
+	 * @param Response res response where the application should produce its
+	 *                     output
 	 */
-	public interface Application : Object {
-
-		/**
-		 * Signal handling a Request and producing a Response.
-		 *
-		 * The rationale behind using a signal is that it allows binding of
-		 * callbacks before and after the default handler is executed, which
-		 * comes very handy for setup and teardown operations like database
-		 * connection.
-		 *
-		 * @since 0.1
-		 *
-		 * @param Request  req request providen to the application by a
-		 *                     VSGI.Server
-		 * @param Response res response where the application should produce its
-		 *                     output
-		 */
-		public virtual signal void handle (Request req, Response res) {}
-	}
+	public delegate void Application (Request req, Response res);
 }

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -246,7 +246,7 @@ namespace VSGI {
 				var res = new VSGI.FastCGIResponse (req, this.request);
 
 				try {
-					this.application.handle (req, res);
+					this.application (req, res);
 				} catch (Error e) {
 					this.request.err.puts (e.message);
 					this.request.out.set_exit_status (e.code);

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -121,7 +121,7 @@ namespace VSGI {
 				var req = new SoupRequest (msg, query);
 				var res = new SoupResponse (req, msg);
 
-				this.application.handle (req, res);
+				this.application (req, res);
 
 				message ("%u %s %s".printf (res.status, req.method, req.uri.get_path ()));
 			};

--- a/tests/vsgi/test_fastcgi.vala
+++ b/tests/vsgi/test_fastcgi.vala
@@ -12,5 +12,5 @@ public static void test_fastcgi_listen () {
 
 	});
 
-	var server = new FastCGIServer (app);
+	var server = new FastCGIServer (app.handler);
 }


### PR DESCRIPTION
Application can be summarized as a callback handling a Request and Response
couple, so it is much more flexible to define it as a delegator.

This way, even Valum is not necessary to write basic web application:

```vala
new SoupServer ((req, res) => {
    res.write ("Hello world!".data);
}).run (args);
```

This way, any VSGI Application can be assigned as a Route handler, opening
interesting composition:

```vala
app.get ("", app.handler); // recursive definition :)
app.get ("", other_app.handler);
app.get ("/scoped/here/<any:path>", other_app.handler);
```

It could be possible, for instance, to compose two frameworks written upon VSGI
specification.