### PR TITLE
Accessing a mapped URL with a wrong method returns a 405

### DIFF
--- a/src/router.vala
+++ b/src/router.vala
@@ -233,13 +233,20 @@ namespace Valum {
 							return;
 						}
 					}
+				// else search for the URI within the other methods
 				} else {
+					Array<string> allowed = new Array<string> ();
+					// foreach method search for the given URI
 					foreach (var method in this.routes.get_keys ()) {
 						foreach (var route in this.routes[method].head) {
 							if (route.match (req)) {
-								throw new ClientError.METHOD_NOT_ALLOWED ("The method %s is not allowed for the request URI %s".printf (req.method, req.uri.to_string (false)));
+								allowed.append_val (method);
 							}
 						}
+					}
+					
+					if (allowed.length > 0) {
+						throw new ClientError.METHOD_NOT_ALLOWED (string.joinv (", ", allowed.data));
 					}
 				}
 
@@ -248,6 +255,9 @@ namespace Valum {
 			} catch (Redirection r) {
 				res.status = r.code;
 				res.headers.append("Location", r.message);
+			} catch (ClientError.METHOD_NOT_ALLOWED e) {
+				res.status = e.code;
+				res.headers.append ("Allow", e.message);
 			} catch (ClientError e) {
 				res.status = e.code;
 			} catch (ServerError e) {

--- a/src/router.vala
+++ b/src/router.vala
@@ -233,6 +233,14 @@ namespace Valum {
 							return;
 						}
 					}
+				} else {
+					foreach (var method in this.routes.get_keys ()) {
+						foreach (var route in this.routes[method].head) {
+							if (route.match (req)) {
+								throw new ClientError.METHOD_NOT_ALLOWED ("The method %s is not allowed for the request URI %s".printf (req.method, req.uri.to_string (false)));
+							}
+						}
+					}
 				}
 
 				throw new ClientError.NOT_FOUND ("The request URI %s was not found.".printf (req.uri.to_string (false)));

--- a/src/router.vala
+++ b/src/router.vala
@@ -241,6 +241,7 @@ namespace Valum {
 						foreach (var route in this.routes[method].head) {
 							if (route.match (req)) {
 								allowed.append_val (method);
+								break;
 							}
 						}
 					}

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -32,3 +32,40 @@ public static void test_router_scope () {
 
 	assert (response.status == 418);
 }
+
+/**
+ * @since 0.1
+ */
+public static void test_router_redirection () {
+	var router = new Router ();
+
+	router.get ("", (req, res) => {
+		throw new Redirection.MOVED_TEMPORARILY ("http://example.com");
+	});
+
+	var request = new TestRequest.with_uri (new Soup.URI ("http://localhost/"));
+	var response = new TestResponse (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (response.status == Soup.Status.MOVED_TEMPORARILY);
+	assert ("http://example.com" == response.headers.get_one ("Location"));
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_custom_method () {
+	var router = new Router ();
+
+	router.method ("TEST", "", (req, res) => {
+		res.status = 418;
+	});
+
+	var request = new TestRequest ("TEST", new Soup.URI ("http://localhost/"));
+	var response = new TestResponse (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (response.status == 418);
+}

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -69,3 +69,26 @@ public static void test_router_custom_method () {
 
 	assert (response.status == 418);
 }
+
+/**
+ * @since 0.1
+ */
+public static void test_router_method_not_allowed () {
+	var router = new Router ();
+	
+	router.get ("", (req, res) => {
+		
+	});
+	
+	router.put ("", (req, res) => {
+		
+	});
+	
+	var request = new TestRequest ("POST", new Soup.URI ("http://localhost/"));
+	var response = new TestResponse (request, Soup.Status.METHOD_NOT_ALLOWED);
+	
+	router.handle (request, response);
+	
+	assert (response.status == 405);
+	assert ("PUT, GET" == response.headers.get_one ("Allow"));
+}

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -6,6 +6,9 @@ public int main (string[] args) {
 	Test.init (ref args);
 
 	Test.add_func ("/router", test_router);
+	Test.add_func ("/router/custom_method", test_router_custom_method);
+	Test.add_func ("/router/scope", test_router_scope);
+	Test.add_func ("/router/redirection", test_router_redirection);
 
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -9,6 +9,7 @@ public int main (string[] args) {
 	Test.add_func ("/router/custom_method", test_router_custom_method);
 	Test.add_func ("/router/scope", test_router_scope);
 	Test.add_func ("/router/redirection", test_router_redirection);
+	Test.add_func ("/router/method_not_allowed", test_router_method_not_allowed);
 
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);

--- a/tests/vsgi/test_request.vala
+++ b/tests/vsgi/test_request.vala
@@ -1,26 +1,28 @@
+using Soup;
+
 /**
  * Test implementation of Request used to stub a request.
  */
 public class TestRequest : VSGI.Request {
 
-	private string _method;
-	private Soup.URI _uri;
-	private Soup.MessageHeaders _headers;
-	private HashTable<string, string> _query;
+	private string _method                    = VSGI.Request.GET;
+	private URI _uri                          = new Soup.URI (null);
+	private MessageHeaders _headers           = new MessageHeaders (MessageHeadersType.REQUEST);
+	private HashTable<string, string>? _query = null;
 
 	public override string method { owned get { return this._method; } }
 
-	public override Soup.URI uri { get { return this._uri; } }
+	public override URI uri { get { return this._uri; } }
 
 	public override HashTable<string, string>? query { get { return this._query; } }
 
-	public override Soup.MessageHeaders headers {
+	public override MessageHeaders headers {
 		get {
 			return this._headers;
 		}
 	}
 
-	public TestRequest (string method, Soup.URI uri, HashTable<string, string>? query = null) {
+	public TestRequest (string method, URI uri, HashTable<string, string>? query = null) {
 		this._method = method;
 		this._uri    = uri;
 		this._query  = query;
@@ -30,7 +32,7 @@ public class TestRequest : VSGI.Request {
 		this._method = method;
 	}
 
-	public TestRequest.with_uri (Soup.URI uri) {
+	public TestRequest.with_uri (URI uri) {
 		this._uri = uri;
 	}
 

--- a/tests/vsgi/test_response.vala
+++ b/tests/vsgi/test_response.vala
@@ -1,10 +1,12 @@
+using Soup;
+
 /**
  * Test implementation of VSGI.Response to stub a response.
  */
 public class TestResponse : VSGI.Response {
 
 	private uint _status;
-	private Soup.MessageHeaders _headers;
+	private MessageHeaders _headers = new MessageHeaders (MessageHeadersType.RESPONSE);
 
 	public override uint status { get { return this._status; } set { this._status = value; } }
 


### PR DESCRIPTION
Instead of just returning a 404 File Not Found when accessing a mapped URL with a non-mapped  method (e.g. `GET /index/` is mapped, `POST /index/` is accessed), now a 405 Method Not Allowed is returned.
This gives more valuable information and is more consistent. This fixes #58.