### PR TITLE
Tests for Router, Route and View.

### DIFF
--- a/src/view.vala
+++ b/src/view.vala
@@ -230,16 +230,10 @@ namespace Valum {
 		/**
 		 * Push an arbitrary {@link GLib.Value} into the environment.
 		 *
-		 * Support is limited to what the environment can hold and the predefined
-		 * functions of this class.
+		 * Support is limited to what the environment can hold.
 		 *
 		 * * null
 		 * * string
-		 * * long
-		 * * double
-		 * * string[]
-		 * * double[]
-		 * * long[]
 		 *
 		 * @since 0.1
 		 *
@@ -252,28 +246,8 @@ namespace Valum {
 				this.environment.push_string (key, "null");
 			}
 
-			else if (Value.type_compatible (val.type (), typeof(string))) {
+			else if (val.holds (typeof (string))) {
 				this.environment.push_string (key, val.get_string ());
-			}
-
-			else if (Value.type_compatible (val.type (), typeof(long))) {
-				this.environment.push_int (key, val.get_int ());
-			}
-
-			else if (Value.type_compatible (val.type (), typeof(double))) {
-				this.environment.push_float (key, val.get_double ());
-			}
-
-			else if (Value.type_compatible (val.type (), typeof(string[]))) {
-				this.push_strings (key, (string[]) val.get_pointer ());
-			}
-
-			else if (Value.type_compatible (val.type (), typeof(long[]))) {
-				this.push_ints (key, (long[]) val.get_pointer ());
-			}
-
-			else if (Value.type_compatible (val.type (), typeof(double[]))) {
-				this.push_floats (key, (double[]) val.get_pointer ());
 			}
 
 			else {

--- a/tests/data/ctpl-template.html
+++ b/tests/data/ctpl-template.html
@@ -1,0 +1,1 @@
+{hello_world}

--- a/tests/test_route.vala
+++ b/tests/test_route.vala
@@ -9,7 +9,6 @@ public void test_route () {
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (req));
-
 }
 
 /**
@@ -50,6 +49,13 @@ public void test_route_from_rule_without_captures () {
 	// ensure params are still null if there is no captures
 	assert (matches);
 	assert (req.params == null);
+}
+
+/**
+ * @since 0.1
+ */
+public void test_route_from_rule_undefined_type () {
+	var route  = new Route.from_rule (new Router (), "<uint:unknown_type>", (req, res) => {});
 }
 
 /**

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -17,6 +17,203 @@ public static void test_router () {
 /**
  * @since 0.1
  */
+public static void test_router_get () {
+	var router = new Router ();
+
+	router.get ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_post () {
+	var router = new Router ();
+
+	router.post ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.POST, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_put () {
+	var router = new Router ();
+
+	router.put ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.PUT, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_delete () {
+	var router = new Router ();
+
+	router.delete ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.DELETE, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_head () {
+	var router = new Router ();
+
+	router.head ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.HEAD, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_options () {
+	var router = new Router ();
+
+	router.options ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.OPTIONS, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_trace () {
+	var router = new Router ();
+
+	router.trace ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.TRACE, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_connect () {
+	var router = new Router ();
+
+	router.connect ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.CONNECT, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+/**
+ * @since 0.1
+ */
+public static void test_router_patch () {
+	var router = new Router ();
+
+	router.patch ("", (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.PATCH, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_regex () {
+	var router = new Router ();
+
+	router.regex (VSGI.Request.GET, /home/, (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/home"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_router_matcher () {
+	var router = new Router ();
+
+	router.matcher (VSGI.Request.GET, (req) => { return req.uri.get_path () == "/"; }, (req, res) => {
+		res.status = 418;
+	});
+
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.1
+ */
 public static void test_router_scope () {
 	var router = new Router ();
 
@@ -51,6 +248,21 @@ public static void test_router_redirection () {
 
 	assert (response.status == Soup.Status.MOVED_TEMPORARILY);
 	assert ("http://example.com" == response.headers.get_one ("Location"));
+}
+
+public static void test_router_server_error () {
+	var router = new Router ();
+
+	router.get ("", (req, res) => {
+		throw new ServerError.INTERNAL_SERVER_ERROR ("Teapot's burning!");
+	});
+
+	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (response.status == Soup.Status.INTERNAL_SERVER_ERROR);
 }
 
 /**

--- a/tests/test_view.vala
+++ b/tests/test_view.vala
@@ -3,6 +3,51 @@ using Valum;
 /**
  * @since 0.1
  */
+public static void test_view_from_string () {
+	var view = new View.from_string ("{hello_world}");
+
+	view.environment.push_string ("hello_world", "test");
+
+	assert ("test" == view.render ());
+
+	// rerender a view
+	assert ("test" == view.render ());
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_view_from_path () {
+	try {
+		var view = new View.from_path ("tests/data/ctpl-template.html");
+
+		view.environment.push_string ("hello_world", "test");
+
+		assert ("test\n" == view.render ());
+	} catch (IOError ioe) {
+		Test.fail ();
+	}
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_view_from_stream () {
+	try {
+		var @in  = File.new_for_path ("tests/data/ctpl-template.html").read ();
+		var view = new View.from_stream (@in);
+
+		view.environment.push_string ("hello_world", "test");
+
+		assert ("test\n" == view.render ());
+	} catch (IOError ioe) {
+		Test.fail ();
+	}
+}
+
+/**
+ * @since 0.1
+ */
 public static void test_view_push_string () {
 	var view = new View ();
 	view.push_string ("key", "value");
@@ -178,6 +223,24 @@ public static void test_view_push_collection_floats () {
 	assert (arr[1] == 0.2);
 	assert (arr[2] == 0.3);
 	*/
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_view_push_collection_unknown_type () {
+	var view       = new View ();
+	var collection = new Gee.ArrayList<Variant> ();
+
+	collection.add (new Variant.int32 (5));
+
+	view.push_collection ("key", collection);
+
+	Ctpl.Value val = null;
+	var popped     = view.environment.pop ("key", ref val);
+
+	assert (popped);
+	assert ("could not infer type GVariant of key" == val.get_string ());
 }
 
 /**
@@ -361,4 +424,35 @@ public static void test_view_push_value_null () {
 	assert (popped);
 
 	assert (val.get_string () == "null");
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_view_push_value_string () {
+	var view = new View ();
+
+	view.push_value ("key", "hello world!");
+
+	Ctpl.Value val = null;
+	var popped     = view.environment.pop ("key", ref val);
+
+	assert (popped);
+
+	assert (val.get_string () == "hello world!");
+}
+
+/**
+ * @since 0.1
+ */
+public static void test_view_push_value_unknown_type () {
+	var view = new View ();
+
+	view.push_value ("key", 5);
+
+	Ctpl.Value val = null;
+	var popped     = view.environment.pop ("key", ref val);
+
+	assert (popped);
+	assert ("unknown type gint for key key" == val.get_string ());
 }

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -8,19 +8,48 @@ public int main (string[] args) {
 	Test.add_func ("/router", test_router);
 	Test.add_func ("/router/custom_method", test_router_custom_method);
 	Test.add_func ("/router/scope", test_router_scope);
+
 	Test.add_func ("/router/redirection", test_router_redirection);
 	Test.add_func ("/router/method_not_allowed", test_router_method_not_allowed);
+	Test.add_func ("/router/server_error", test_router_server_error);
+
+	Test.add_func ("/router/get", test_router_get);
+	Test.add_func ("/router/post", test_router_post);
+	Test.add_func ("/router/put", test_router_put);
+	Test.add_func ("/router/delete", test_router_delete);
+	Test.add_func ("/router/head", test_router_head);
+	Test.add_func ("/router/options", test_router_options);
+	Test.add_func ("/router/trace", test_router_trace);
+	Test.add_func ("/router/connect", test_router_connect);
+	Test.add_func ("/router/patch", test_router_patch);
+
+	Test.add_func ("/router/regex", test_router_regex);
+	Test.add_func ("/router/matcher", test_router_matcher);
 
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);
 	Test.add_func ("/route/from_rule/any", test_route_from_rule_any);
 	Test.add_func ("/route/from_rule/without_captures", test_route_from_rule_without_captures);
+
+#if GLIB_2_38
+	Test.add_func ("/route/from_rule/undefined_type", () => {
+		Test.trap_subprocess ("/route/from_rule/undefined_type/subprocess", 0, 0);
+		Test.trap_assert_failed ();
+	});
+
+	Test.add_func ("/route/from_rule/undefined_type/subprocess", test_route_from_rule_undefined_type);
+#endif
+
 	Test.add_func ("/route/from_regex", test_route_from_regex);
 	Test.add_func ("/route/from_regex/scoped", test_route_from_regex_scoped);
 	Test.add_func ("/route/from_regex/without_captures", test_route_from_regex_without_captures);
 	Test.add_func ("/route/match", test_route_match);
 	Test.add_func ("/route/match/not_matching", test_route_match_not_matching);
 	Test.add_func ("/route/fire", test_route_match_not_matching);
+
+	Test.add_func ("/view/from_string", test_view_from_string);
+	Test.add_func ("/view/from_path", test_view_from_path);
+	Test.add_func ("/view/from_stream", test_view_from_stream);
 
 	Test.add_func ("/view/push_string", test_view_push_string);
 	Test.add_func ("/view/push_int", test_view_push_int);
@@ -33,6 +62,7 @@ public int main (string[] args) {
 	Test.add_func ("/view/push_collection/strings", test_view_push_collection_strings);
 	Test.add_func ("/view/push_collection/ints", test_view_push_collection_ints);
 	Test.add_func ("/view/push_collection/floats", test_view_push_collection_floats);
+	Test.add_func ("/view/push_collection/unknown_type", test_view_push_collection_unknown_type);
 
 	Test.add_func ("/view/push_map", test_view_push_map);
 	Test.add_func ("/view/push_string_map", test_view_push_string_map);
@@ -46,5 +76,8 @@ public int main (string[] args) {
 	Test.add_func ("/view/push_int_hashtable", test_view_push_int_hashtable);
 
 	Test.add_func ("/view/push_value/null", test_view_push_value_null);
+	Test.add_func ("/view/push_value/string", test_view_push_value_string);
+	Test.add_func ("/view/push_value/unknown_type", test_view_push_value_unknown_type);
+
 	return Test.run ();
 }

--- a/wscript
+++ b/wscript
@@ -23,6 +23,10 @@ def configure(conf):
     conf.check_cfg(package='gee-0.8', atleast_version='0.6.4', uselib_store='GEE', args='--cflags --libs')
     conf.check_cfg(package='libsoup-2.4', atleast_version='2.38',uselib_store='SOUP', args='--cflags --libs')
 
+    # glib (>=2.38) to enable subprocess in tests
+    if conf.check_cfg(package='glib-2.0', atleast_version='2.38', mandatory=False, uselib_store='GLIB', args='--cflags --libs'):
+        conf.env.append_unique('VALAFLAGS', ['--define=GIO_2_38'])
+
     # gio (>=2.40) is necessary for CLI arguments parsing
     if conf.check_cfg(package='gio-2.0', atleast_version='2.40', mandatory=False, uselib_store='GIO', args='--cflags --libs'):
         conf.env.append_unique('VALAFLAGS', ['--define=GIO_2_40'])


### PR DESCRIPTION
Tests for all Router built-in HTTP methods and ServerError thrown in a handler.

Test for creating a Route from a rule using an undefined type. Since it's
requiring a subprocess trap, it is conditionnaly built with glib (>=2.38).

Tests for View were added:

 - tests for view creation from string, path and stream
 - test for pushing a collection containing an unknown type
 - test for pushing string with push_value
 - test for push an unknown type with push_value

Removes non-working types from push_value, it seems like typeof does not work on
primitives or array of primitives.