### PR TITLE
WIP: Request and Response body can be setted.

### DIFF
--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -1,6 +1,14 @@
 Response
 ========
 
+Responses are representing resources requested by a client. They are actively
+streamed across the network, preferably using non-blocking asynchronous I/O.
+
+Any operations on a response must eventually invoke ``end``, this is how it is
+figured out that the response has completed its processing and resources
+associated to it can be released. This enables the possibility to keep
+a reference to the response in `AsyncResult`.
+
 Status
 ------
 
@@ -83,3 +91,6 @@ a great incidence on the application throughput.
         // send a success mail
         Mailer.send ("johndoe@example.com", "Had to close that stream mate!");
     });
+
+End the response
+---------------

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -10,50 +10,55 @@ mcd.add_server ("127.0.0.1", 11211);
 // extra route types
 app.types["permutations"] = /abc|acb|bac|bca|cab|cba/;
 
-var timer  = new Timer ();
-
 app.setup.connect ((req, res) => {
-	timer.start ();
-});
+	var timer  = new Timer ();
 
-app.teardown.connect ((req, res) => {
-	timer.stop ();
-	var elapsed = timer.elapsed ();
-	res.headers.append ("X-Runtime", "%8.3fms".printf (elapsed * 1000));
-	message ("%s computed in %8.3fms", req.uri.get_path (), elapsed * 1000);
+	res.end.connect (() => {
+		timer.stop ();
+		var elapsed = timer.elapsed ();
+		res.headers.append ("X-Runtime", "%8.3fms".printf (elapsed * 1000));
+		message ("%s computed in %8.3fms", req.uri.get_path (), elapsed * 1000);
+	});
+
+	timer.start ();
 });
 
 // default route
 app.get ("", (req, res) => {
 	var template = new View.from_stream (resources_open_stream ("/templates/home.html", ResourceLookupFlags.NONE));
 
-	template.stream (res);
+	template.stream (res.body);
+	res.end ();
 });
 
 app.get ("query", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
 
 	if (req.query != null) {
 		req.query.foreach ((k, v) => {
-		writer.put_string ("%s: %s\n".printf (k, v));
-	});
+			writer.put_string ("%s: %s\n".printf (k, v));
+		});
 	}
+
+	res.end ();
 });
 
 app.get ("headers", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
 
 	req.headers.foreach ((name, header) => {
 		writer.put_string ("%s: %s\n".printf (name, header));
 	});
+
+	res.end ();
 });
 
 app.get ("cookies", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
 
@@ -62,37 +67,43 @@ app.get ("cookies", (req, res) => {
 	foreach (var cookie in req.cookies) {
 		writer.put_string ("%s: %s\n".printf (cookie.name, cookie.value));
 	}
+
+	res.end ();
 });
 
 app.get ("custom-route-type/<permutations:p>", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string (req.params["p"]);
+	res.end ();
 });
 
 // hello world! (compare with Node.js!)
 app.get ("hello", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("Hello world\n");
+	res.end ();
 });
 
 // hello with a trailing slash
 app.get ("hello/", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("Hello world\n");
+	res.end ();
 });
 
 // example using route parameter
 app.get ("hello/<id>", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("hello %s!".printf (req.params["id"]));
+	res.end ();
 });
 
 app.scope ("urlencoded-data", (inner) => {
 	inner.get ("", (req, res) => {
-		var writer = new DataOutputStream (res);
+		var writer = new DataOutputStream (res.body);
 		writer.put_string (
 		"""
 		<!DOCTYPE html>
@@ -105,17 +116,20 @@ app.scope ("urlencoded-data", (inner) => {
 		  </body>
 		</html>
 		""");
+		res.end ();
 	});
 
 	inner.post ("", (req, res) => {
-		var writer = new DataOutputStream (res);
+		var writer = new DataOutputStream (res.body);
 		var data   = new MemoryOutputStream (null, realloc, free);
 
-		data.splice (req, OutputStreamSpliceFlags.CLOSE_SOURCE);
+		data.splice (req.body, OutputStreamSpliceFlags.CLOSE_SOURCE);
 
 		Soup.Form.decode ((string) data.get_data ()).foreach ((k, v) => {
 			writer.put_string ("%s: %s".printf (k, v));
 		});
+
+		res.end ();
 	});
 });
 
@@ -123,28 +137,33 @@ app.scope ("urlencoded-data", (inner) => {
 app.get ("users/<int:id>/<action>", (req, res) => {
 	var id     = req.params["id"];
 	var test   = req.params["action"];
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
 
 	writer.put_string (@"id\t=> $id\n");
 	writer.put_string (@"action\t=> $test");
+
+	res.end ();
 });
 
 // lua scripting
 app.get ("lua", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string (lua.eval ("""
 		require "markdown"
 		return markdown('## Hello from lua.eval!')
 	"""));
 
 	writer.put_string (lua.run ("examples/app/hello.lua"));
+
+	res.end ();
 });
 
 app.get ("lua.haml", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string (lua.run ("examples/app/haml.lua"));
+	res.end ();
 });
 
 
@@ -165,24 +184,27 @@ app.get ("ctpl/<foo>/<bar>", (req, res) => {
 	tpl.push_strings ("strings", {"a", "b", "c"});
 	tpl.push_int ("int", 1);
 
-	tpl.stream (res);
+	tpl.stream (res.body);
+	res.end ();
 });
 
 // memcached
 app.get ("memcached/get/<key>", (req, res) => {
 	var value = mcd.get (req.params["key"]);
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string (value);
+	res.end ();
 });
 
 // TODO: rewrite using POST
 app.get ("memcached/set/<key>/<value>", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	if (mcd.set (req.params["key"], req.params["value"])) {
 		writer.put_string ("Ok! Pushed.");
 	} else {
 		writer.put_string ("Fail! Not Pushed...");
 	}
+	res.end ();
 });
 
 // scoped routing
@@ -192,22 +214,23 @@ app.scope ("admin", (adm) => {
 		// matches /admin/fun/hack
 		fun.get ("hack", (req, res) => {
 			var time = new DateTime.now_utc ();
-			var writer = new DataOutputStream (res);
+			var writer = new DataOutputStream (res.body);
 			res.headers.set_content_type ("text/plain", null);
 			writer.put_string ("It's %s around here!\n".printf (time.format ("%H:%M")));
+			res.end ();
 		});
 		// matches /admin/fun/heck
 		fun.get ("heck", (req, res) => {
-			var writer = new DataOutputStream (res);
+			var writer = new DataOutputStream (res.body);
 			res.headers.set_content_type ("text/plain", null);
 			writer.put_string ("Wuzzup!");
+			res.end ();
 		});
 	});
 });
 
 // serve static resource using a path route parameter
 app.get ("static/<path:resource>.<any:type>", (req, res) => {
-	var writer = new DataOutputStream (res);
 	var resource = req.params["resource"];
 	var type     = req.params["type"];
 	var contents = new uint8[128];
@@ -226,10 +249,12 @@ app.get ("static/<path:resource>.<any:type>", (req, res) => {
 		var file = resources_open_stream (path, ResourceLookupFlags.NONE);
 
 		// transfer the file
-		res.splice (file, OutputStreamSpliceFlags.CLOSE_SOURCE);
+		res.body.splice_async.begin (file, OutputStreamSpliceFlags.CLOSE_SOURCE, Priority.DEFAULT, null, (obj, result) => {
+			var size = res.body.splice_async.end (result);
+			res.end ();
+		});
 	} catch (Error e) {
-		res.status = 404;
-		writer.put_string (e.message);
+		throw new ClientError.NOT_FOUND (e.message);
 	}
 });
 
@@ -242,25 +267,29 @@ app.get ("not-found", (req, res) => {
 });
 
 app.method (VSGI.Request.GET, "custom-method", (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string (req.method);
+	res.end ();
 });
 
 app.regex (VSGI.Request.GET, /custom-regular-expression/, (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string ("This route was matched using a custom regular expression.");
+	res.end ();
 });
 
 app.matcher (VSGI.Request.GET, (req) => { return req.uri.get_path () == "/custom-matcher"; }, (req, res) => {
-	var writer = new DataOutputStream (res);
+	var writer = new DataOutputStream (res.body);
 	writer.put_string ("This route was matched using a custom matcher.");
+	res.end ();
 });
 
 var api = new Router ();
 
 api.get ("repository/<name>", (req, res) => {
 	var name = req.params["name"];
-	res.write (name.data);
+	res.body.write (name.data);
+	res.end ();
 });
 
 // delegate all other GET requests to a subrouter
@@ -270,7 +299,7 @@ app.teardown.connect ((req, res) => {
 	if (res.status == 404) {
 		var template = new View.from_stream (resources_open_stream ("/templates/404.html", ResourceLookupFlags.NONE));
 		template.environment.push_string ("path", req.uri.get_path ());
-		template.stream (res);
+		template.stream (res.body);
 	}
 });
 

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -6,24 +6,29 @@ public static int main (string[] args) {
 
 	// default route
 	app.get ("", (req, res) => {
-		res.write ("Hello world!".data);
+		res.body.write ("Hello world!".data);
+		res.end ();
 	});
 
 	app.get ("random/<int:size>", (req, res) => {
 		var size   = int.parse (req.params["size"]);
-		var writer = new DataOutputStream (res);
+		var writer = new DataOutputStream (res.body);
 
 		for (; size > 0; size--) {
 			// write byte to byte
 			writer.put_uint32 (Random.next_int ());
 		}
+
+		res.end ();
 	});
 
 	app.get ("<any:path>", (req, res) => {
 		res.status = 404;
 
-		var writer = new DataOutputStream (res);
+		var writer = new DataOutputStream (res.body);
 		writer.put_string ("404 - Not found");
+
+		res.end ();
 	});
 
 	return new Server (app).run (args);

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -6,6 +6,7 @@ public static int main (string[] args) {
 
 	// default route
 	app.get ("", (req, res) => {
+		res.headers.set_encoding (Soup.Encoding.CHUNKED);
 		res.body.write ("Hello world!".data);
 		res.end ();
 	});

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -6,7 +6,6 @@ public static int main (string[] args) {
 
 	// default route
 	app.get ("", (req, res) => {
-		res.headers.set_encoding (Soup.Encoding.CHUNKED);
 		res.body.write ("Hello world!".data);
 		res.end ();
 	});

--- a/src/router.vala
+++ b/src/router.vala
@@ -44,14 +44,18 @@ namespace Valum {
 		 * Setup a request before its processing begins.
 		 *
 		 * The default handler initializes the response with sane default such
-		 * as 200 status code, 'text/html' content type and request cookies. Use
-		 * 'connect_after' if you want to override any of these defaults.
+		 * as 200 status code, 'text/html' content type, 'chunked' transfer
+		 * encoding and request cookies.
+		 *
+		 * Use 'connect_after' if you want to override any of these defaults.
 		 *
 		 * @since 0.1
 		 */
 		public virtual signal void setup (Request req, Response res) {
 			res.status = Soup.Status.OK;
 			res.headers.set_content_type ("text/html", null);
+			if (req.http_version == Soup.HTTPVersion.@1_1)
+				res.headers.set_encoding (Soup.Encoding.CHUNKED);
 			res.cookies = req.cookies;
 		}
 

--- a/src/router.vala
+++ b/src/router.vala
@@ -224,6 +224,11 @@ namespace Valum {
 		public void handle (Request req, Response res) {
 			setup (req, res);
 
+			// teardown the response before the stream is closed
+			res.end.connect (() => {
+				teardown (req, res);
+			});
+
 			try {
 				// ensure at least one route has been declared with that method
 				if (this.routes.contains (req.method)) {
@@ -269,13 +274,9 @@ namespace Valum {
 			} finally {
 				teardown (req, res);
 			}
-		}
 
-		/**
-		 * {@inheritDoc}
-		 */
-		public async void handle_async (Request req, Response res) {
-			this.handle (req, res);
+			// in case of exception, always end the response properly
+			res.end ();
 		}
 	}
 }

--- a/src/vsgi/application.vala
+++ b/src/vsgi/application.vala
@@ -29,6 +29,7 @@ namespace VSGI {
 		 * @param req request providen to the application by a
 		 *            {@link VSGI.Server}
 		 * @param res response where the application should produce its output
+		 * @param end called to end the processing of the response
 		 */
 		public abstract void handle (Request req, Response res);
 	}

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -183,7 +183,11 @@ namespace VSGI.FastCGI {
 
 		public override MessageHeaders headers { get { return this._headers; } }
 
+		private OutputStream? _body = null;
+
 		/**
+		 * {@inheritDoc}
+		 *
 		 * The HTTP server already handles the 'Transfer-Encoding' header.
 		 */
 		public override OutputStream body {
@@ -201,7 +205,14 @@ namespace VSGI.FastCGI {
 					this.headers_written = true;
 				}
 
+				// body has been filtered
+				if (this._body != null)
+					return this._body;
+
 				return this.raw_body;
+			}
+			set {
+				this._body = body;
 			}
 		}
 

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -184,30 +184,29 @@ namespace VSGI.FastCGI {
 		public override MessageHeaders headers { get { return this._headers; } }
 
 		/**
-		 * Tells if the head of the response has been written.
-		 */
-		private bool head_written = false;
-
-		/**
 		 * The HTTP server already handles the 'Transfer-Encoding' header.
 		 */
 		public override OutputStream body {
 			get {
-				if (this.head_written)
-					return this.output_stream;
+				if (this.headers_written)
+					return this.raw_body;
 
-				this.write_status_line ();
+				if (!this.status_line_written) {
+					this.write_status_line ();
+					this.status_line_written = true;
+				}
 
-				this.write_headers ();
+				if (!this.headers_written) {
+					this.write_headers ();
+					this.headers_written = true;
+				}
 
-				this.head_written = true;
-
-				return this.output_stream;
+				return this.raw_body;
 			}
 		}
 
 		public Response (Request req, Stream @out, Stream err) {
-			Object (request: req, output_stream: new StreamOutputStream (@out, err));
+			Object (request: req, raw_body: new StreamOutputStream (@out, err));
 		}
 
 		/**

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -183,6 +183,29 @@ namespace VSGI.FastCGI {
 
 		public override MessageHeaders headers { get { return this._headers; } }
 
+		/**
+		 * Tells if the head of the response has been written.
+		 */
+		private bool head_written = false;
+
+		/**
+		 * The HTTP server already handles the 'Transfer-Encoding' header.
+		 */
+		public override OutputStream body {
+			get {
+				if (this.head_written)
+					return this.output_stream;
+
+				this.write_status_line ();
+
+				this.write_headers ();
+
+				this.head_written = true;
+
+				return this.output_stream;
+			}
+		}
+
 		public Response (Request req, Stream @out, Stream err) {
 			Object (request: req, output_stream: new StreamOutputStream (@out, err));
 		}

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -3,8 +3,80 @@ using Soup;
 
 /**
  * FastCGI implementation of VSGI.
+ *
+ * @since 0.1
  */
 namespace VSGI.FastCGI {
+	class StreamInputStream : InputStream {
+
+		public unowned global::FastCGI.Stream stream { construct; get; }
+
+		public StreamInputStream (global::FastCGI.Stream stream) {
+			Object (stream: stream);
+		}
+
+		public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
+			var read = this.stream.read (buffer);
+
+			if (read == GLib.FileStream.EOF)
+				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.stream.get_error ()), strerror (FileUtils.error_from_errno (this.stream.get_error ())));
+
+			return read;
+		}
+
+		public override bool close (Cancellable? cancellable = null) throws IOError {
+			if (this.stream.close () == -1)
+				throw new Error (IOError.quark (),
+						         FileUtils.error_from_errno (this.stream.get_error ()),
+								 strerror (FileUtils.error_from_errno (this.stream.get_error ())));
+
+			return this.stream.is_closed;
+		}
+	}
+
+	class StreamOutputStream : OutputStream {
+
+		public unowned global::FastCGI.Stream @out { construct; get; }
+
+		public unowned global::FastCGI.Stream err { construct; get; }
+
+		public StreamOutputStream (global::FastCGI.Stream @out, global::FastCGI.Stream err) {
+			Object (@out: @out, err: err);
+		}
+
+		public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
+			var written = this.out.put_str (buffer);
+
+			if (written == GLib.FileStream.EOF)
+				throw new Error (IOError.quark (),
+						         FileUtils.error_from_errno (this.out.get_error ()),
+								 strerror (FileUtils.error_from_errno (this.out.get_error ())));
+
+			return written;
+		}
+
+		/**
+		 * Headers are written on the first flush call.
+		 */
+		public override bool flush (Cancellable? cancellable = null) {
+			return this.out.flush ();
+		}
+
+		public override bool close (Cancellable? cancellable = null) throws IOError {
+			if (this.out.close () == -1)
+				throw new Error (IOError.quark (),
+						         FileUtils.error_from_errno (this.out.get_error ()),
+								 strerror (FileUtils.error_from_errno (this.out.get_error ())));
+
+			if (this.err.close () == -1)
+				throw new Error (IOError.quark (),
+						         FileUtils.error_from_errno (this.err.get_error ()),
+								 strerror (FileUtils.error_from_errno (this.err.get_error ())));
+
+			return this.out.is_closed && this.err.is_closed;
+		}
+	}
+
 	/**
 	 * FastCGI Request implementation.
 	 *
@@ -22,11 +94,6 @@ namespace VSGI.FastCGI {
 		private URI _uri = new URI (null);
 		private HashTable<string, string>? _query = null;
 		private MessageHeaders _headers = new MessageHeaders (MessageHeadersType.REQUEST);
-
-		/**
-		 *
-		 */
-		private unowned Stream @in;
 
 		public override HTTPVersion http_version {
 			get { return this._http_version; }
@@ -49,7 +116,7 @@ namespace VSGI.FastCGI {
 		}
 
 		public Request (global::FastCGI.request request) {
-			this.in = request.in;
+			Object (body: new StreamInputStream (request.in));
 
 			var environment = request.environment;
 
@@ -94,22 +161,6 @@ namespace VSGI.FastCGI {
 
 			global::Soup.headers_parse (headers.str, (int) headers.len, this._headers);
 		}
-
-		public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
-			var read = this.in.read (buffer);
-
-			if (read == GLib.FileStream.EOF)
-				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.in.get_error ()), strerror (FileUtils.error_from_errno (this.in.get_error ())));
-
-			return read;
-		}
-
-		public override bool close (Cancellable? cancellable = null) throws IOError {
-			if (this.in.close () == -1)
-				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.in.get_error ()), strerror (FileUtils.error_from_errno (this.in.get_error ())));
-
-			return this.in.is_closed;
-		}
 	}
 
 	/**
@@ -117,98 +168,30 @@ namespace VSGI.FastCGI {
 	 */
 	class Response : VSGI.Response {
 
-		private unowned Stream @out;
-		private unowned Stream err;
-
-		/**
-		 * Tells if the headers part of the HTTP message has been written to the
-		 * output stream.
-		 */
-		private bool headers_written = false;
-
 		private uint _status;
 
 		private MessageHeaders _headers = new MessageHeaders (MessageHeadersType.RESPONSE);
 
 		public override uint status {
 			get { return this._status; }
-			set { this._status = value; }
+			set {
+				this._status = value;
+				// update the 'Status' header
+				this._headers.replace ("Status", "%u %s".printf (value, Status.get_phrase (value)));
+			}
 		}
 
 		public override MessageHeaders headers { get { return this._headers; } }
 
 		public Response (Request req, Stream @out, Stream err) {
-			Object (request: req);
-			this.out = @out;
-			this.err = err;
-		}
-
-		private ssize_t write_headers () throws IOError {
-			// headers cannot be rewritten
-			if (this.headers_written)
-				error ("headers have already been written");
-
-			var headers = new StringBuilder ();
-
-			// status
-			headers.append ("Status: %u %s\r\n".printf (this.status, Status.get_phrase (this.status)));
-
-			// headers
-			this.headers.foreach ((k, v) => {
-				headers.append ("%s: %s\r\n".printf(k, v));
-			});
-
-			// newline preceeding the body
-			headers.append ("\r\n");
-
-			// write headers in a single operation
-			var written = this.out.puts (headers.str);
-
-			if (written == GLib.FileStream.EOF)
-				return written;
-
-			// headers are written if the write operation is successful (rewritten otherwise)
-			this.headers_written = true;
-
-			return written;
-		}
-
-		public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
-			// lock so that two threads would not write headers at the same time.
-			lock (this.headers_written) {
-				if (!this.headers_written)
-					this.write_headers ();
-			}
-
-			var written = this.out.put_str (buffer);
-
-			if (written == GLib.FileStream.EOF)
-				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.out.get_error ()), strerror (FileUtils.error_from_errno (this.out.get_error ())));
-
-			return written;
+			Object (request: req, output_stream: new StreamOutputStream (@out, err));
 		}
 
 		/**
-		 * Headers are written on the first flush call.
+		 * The status line is part of the headers, so nothing has to be done here.
 		 */
-		public override bool flush (Cancellable? cancellable = null) {
-			return this.out.flush ();
-		}
-
-		public override bool close (Cancellable? cancellable = null) throws IOError {
-			// lock so that two threads would not write headers at the same time.
-			lock (this.headers_written) {
-				if (!this.headers_written)
-					this.write_headers ();
-			}
-
-			if (this.err.close () == -1)
-				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.err.get_error ()), strerror (FileUtils.error_from_errno (this.err.get_error ())));
-
-			if (this.out.close () == -1)
-				throw new Error (IOError.quark (), FileUtils.error_from_errno (this.out.get_error ()), strerror (FileUtils.error_from_errno (this.out.get_error ())));
-
-			return this.err.is_closed && this.out.is_closed;
+		protected override ssize_t write_status_line () throws IOError {
+			return 0;
 		}
 	}
 
@@ -319,14 +302,14 @@ namespace VSGI.FastCGI {
 				var req = new Request (request);
 				var res = new Response (req, request.out, request.err);
 
+				res.end.connect_after (() => {
+					message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
+					request.finish ();
+					request.close (false); // keep the socket open
+					release ();
+				});
+
 				this.application.handle (req, res);
-
-				message ("%s: %u %s %s", this.get_application_id (), res.status, req.method, req.uri.get_path ());
-
-				request.finish ();
-				request.close (false); // keep the socket open
-
-				this.release ();
 
 				return true;
 			});

--- a/src/vsgi/request.vala
+++ b/src/vsgi/request.vala
@@ -6,7 +6,7 @@ namespace VSGI {
 	 *
 	 * @since 0.0.1
 	 */
-	public abstract class Request : InputStream {
+	public abstract class Request : Object {
 
 		/**
 		 * HTTP/1.1 standard methods.
@@ -124,5 +124,12 @@ namespace VSGI {
 				return cookies;
 			}
 		}
+
+		/**
+		 * Request body.
+		 *
+		 * @since 0.2
+		 */
+		public InputStream body { construct; get; }
 	}
 }

--- a/src/vsgi/request.vala
+++ b/src/vsgi/request.vala
@@ -130,6 +130,6 @@ namespace VSGI {
 		 *
 		 * @since 0.2
 		 */
-		public InputStream body { construct; get; }
+		public InputStream body { get; construct set; }
 	}
 }

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -1,3 +1,4 @@
+using GLib;
 using Soup;
 
 namespace VSGI {
@@ -6,7 +7,7 @@ namespace VSGI {
 	 *
 	 * @since 0.0.1
 	 */
-	public abstract class Response : OutputStream {
+	public abstract class Response : Object {
 
 		/**
 		 * Request to which this response is responding.
@@ -45,6 +46,151 @@ namespace VSGI {
 					this.headers.append ("Set-Cookie", cookie.to_set_cookie_header ());
 				}
 			}
+		}
+
+		/**
+		 * Response raw stream.
+		 *
+		 * @since 0.2
+		 */
+		public OutputStream output_stream { construct; protected get; }
+
+		/**
+		 * Placeholder for the stream used in body property.
+		 */
+		private OutputStream? _body = null;
+
+		/**
+		 * Response body.
+		 *
+		 * On the first attempt to access the response body stream, the status
+		 * line and headers will be written in the response stream. Subsequent
+		 * accesses will remain the stream untouched.
+		 *
+		 * The provided stream is safe for transfer encoding, so unless the
+		 * server technology guarantees that already, VSGI provide basic stream
+		 * filters for that purpose.
+		 *
+		 * The default implementation is to return the output_stream property,
+		 * assuming that the server does transfer encoding properly.
+		 *
+		 * @since 0.2
+		 */
+		public virtual OutputStream body {
+			get {
+				if (this._body != null)
+					return this._body;
+
+				this.write_status_line ();
+
+				this.write_headers ();
+
+				this._body = this.output_stream;
+
+				return this._body;
+			}
+		}
+
+		/**
+		 * Write the HTTP status line in the response stream.
+		 *
+		 * This must be invoked before any headers writing operations,
+		 * preferably with the response status property and protocol
+		 * version.
+		 *
+		 * @since 0.2
+		 *
+		 * @param status   response status code
+		 * @param protocol HTTP protocol and version, eg. HTTP/1.1
+		 */
+		protected virtual ssize_t write_status_line () throws IOError {
+			var status_line = "%s %u %s\r\n".printf ("HTTP/1.1", status, Status.get_phrase (status));
+			return this.output_stream.write (status_line.data);
+		}
+
+		/**
+		 * Write the given headers in the response stream.
+		 *
+		 * It is invoked once before the body is written and can be invoked
+		 * later to produce multipart messages.
+		 *
+		 * @since 0.2
+		 *
+		 * @param headers headers to write in the response stream
+		 */
+		protected virtual ssize_t write_headers () throws IOError {
+			ssize_t written = 0;
+
+			// headers
+			this.headers.foreach ((k, v) => {
+				written += this.output_stream.write ("%s: %s\r\n".printf (k, v).data);
+			});
+
+			// newline preceeding the body
+			written += this.output_stream.write ("\r\n".data);
+
+			return written;
+		}
+
+		/**
+		 * End the {@link Response} processing and notify that event to the
+		 * listeners.
+		 *
+		 * The default handler will close the body.
+		 *
+		 * @since 0.2
+		 */
+		public virtual signal void end () {
+			if (!this.body.is_closed ())
+				this.body.close ();
+		}
+	}
+
+	/**
+	 * Provide chunking capability to a stream.
+	 *
+	 * @since 0.2
+	 */
+	public class ChunkedOutputStream : FilterOutputStream {
+
+		public ChunkedOutputStream (OutputStream base_stream) {
+			Object (base_stream: base_stream);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 *
+		 * Writing has an expansion factor of ceil(log_16(data.length)) + 4
+		 * due to the presence of newlines and predicted size of a chunk.
+		 */
+		public override ssize_t write (uint8[] data, Cancellable? cancellable = null) throws IOError {
+			ssize_t written = 0;
+
+			// write the size
+			written += this.base_stream.write ("%X\r\n".printf (data.length).data, cancellable);
+
+			// write the chunk
+			written += this.base_stream.write (data, cancellable);
+
+			// terminate the chunk
+			written += this.base_stream.write ("\r\n".data, cancellable);
+
+			return written;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Closing the stream will write 5 bytes if the choosed encoding is
+		 * {@link Soup.Encoding.CHUNKED}.
+		 *
+		 * @since 0.2
+		 */
+		public override bool close (Cancellable? cancellable = null) throws IOError {
+			this.base_stream.write ("0\r\n".data, cancellable);
+			this.base_stream.write ("\r\n".data, cancellable);
+
+			return this.base_stream.close (cancellable);
 		}
 	}
 }

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -67,12 +67,8 @@ namespace VSGI {
 		 * line and headers will be written in the response stream. Subsequent
 		 * accesses will remain the stream untouched.
 		 *
-		 * The provided stream is safe for transfer encoding, so unless the
-		 * server technology guarantees that already, VSGI provide basic stream
-		 * filters for that purpose.
-		 *
-		 * The default implementation is to return the output_stream property,
-		 * assuming that the server does transfer encoding properly.
+		 * The provided stream is safe for transfer encoding and will filter
+		 * the stream properly if it's chunked.
 		 *
 		 * @since 0.2
 		 */
@@ -86,6 +82,11 @@ namespace VSGI {
 				this.write_headers ();
 
 				this._body = this.output_stream;
+
+				// filter the stream properly
+				if (this.headers.get_encoding () == Encoding.CHUNKED) {
+					this._body = new ChunkedOutputStream (output_stream);
+				}
 
 				return this._body;
 			}
@@ -181,8 +182,7 @@ namespace VSGI {
 		/**
 		 * {@inheritDoc}
 		 *
-		 * Closing the stream will write 5 bytes if the choosed encoding is
-		 * {@link Soup.Encoding.CHUNKED}.
+		 * Closing the stream will write 5 bytes to end the chunking properly.
 		 *
 		 * @since 0.2
 		 */

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -63,6 +63,10 @@ namespace VSGI {
 		/**
 		 * Response body.
 		 *
+		 * The body should be setted with a {@link FilterOutputStream} wrapping
+		 * the current body. This can be used to implement specific
+		 * 'Content-Encoding'.
+		 *
 		 * On the first attempt to access the response body stream, the status
 		 * line and headers will be written in the response stream. Subsequent
 		 * accesses will remain the stream untouched.
@@ -95,6 +99,9 @@ namespace VSGI {
 				}
 
 				return this._body;
+			}
+			set {
+				this._body = value;
 			}
 		}
 

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -49,14 +49,14 @@ namespace VSGI {
 		}
 
 		/**
-		 * Response raw stream.
+		 * Response raw body.
 		 *
 		 * @since 0.2
 		 */
-		public OutputStream output_stream { construct; protected get; }
+		public OutputStream raw_body { construct; protected get; }
 
 		/**
-		 * Placeholder for the stream used in body property.
+		 * Placeholder for the filtered raw body.
 		 */
 		private OutputStream? _body = null;
 
@@ -77,15 +77,21 @@ namespace VSGI {
 				if (this._body != null)
 					return this._body;
 
-				this.write_status_line ();
+				if (!this.status_line_written) {
+					this.write_status_line ();
+					this.status_line_written = true;
+				}
 
-				this.write_headers ();
+				if (!this.headers_written) {
+					this.write_headers ();
+					this.headers_written = true;
+				}
 
-				this._body = this.output_stream;
+				this._body = this.raw_body;
 
 				// filter the stream properly
 				if (this.headers.get_encoding () == Encoding.CHUNKED) {
-					this._body = new ChunkedOutputStream (output_stream);
+					this._body = new ChunkedOutputStream (raw_body);
 				}
 
 				return this._body;
@@ -93,8 +99,14 @@ namespace VSGI {
 		}
 
 		/**
-		 * Write the HTTP status line in the response stream.
+		 * @since 0.2
+		 */
+		protected bool status_line_written = false;
+
+		/**
+		 * Write the HTTP status line in the response raw body.
 		 *
+		 * It is invoked once when the body is accessed for the first time.
 		 * This must be invoked before any headers writing operations,
 		 * preferably with the response status property and protocol
 		 * version.
@@ -106,11 +118,16 @@ namespace VSGI {
 		 */
 		protected virtual ssize_t write_status_line () throws IOError {
 			var status_line = "%s %u %s\r\n".printf ("HTTP/1.1", status, Status.get_phrase (status));
-			return this.output_stream.write (status_line.data);
+			return this.raw_body.write (status_line.data);
 		}
 
 		/**
-		 * Write the given headers in the response stream.
+		 * @since 0.2
+		 */
+		protected bool headers_written = false;
+
+		/**
+		 * Write the headers in the response raw body.
 		 *
 		 * It is invoked once before the body is written and can be invoked
 		 * later to produce multipart messages.
@@ -124,11 +141,11 @@ namespace VSGI {
 
 			// headers
 			this.headers.foreach ((k, v) => {
-				written += this.output_stream.write ("%s: %s\r\n".printf (k, v).data);
+				written += this.raw_body.write ("%s: %s\r\n".printf (k, v).data);
 			});
 
 			// newline preceeding the body
-			written += this.output_stream.write ("\r\n".data);
+			written += this.raw_body.write ("\r\n".data);
 
 			return written;
 		}
@@ -137,11 +154,22 @@ namespace VSGI {
 		 * End the {@link Response} processing and notify that event to the
 		 * listeners.
 		 *
-		 * The default handler will close the body.
+		 * The default handler will write the status line, write the response
+		 * headers and close the body if any of these is not already done.
 		 *
 		 * @since 0.2
 		 */
 		public virtual signal void end () {
+			if (!this.status_line_written) {
+				this.write_status_line ();
+				this.status_line_written = true;
+			}
+
+			if (!this.headers_written) {
+				this.write_headers ();
+				this.headers_written = true;
+			}
+
 			if (!this.body.is_closed ())
 				this.body.close ();
 		}

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -52,26 +52,6 @@ namespace VSGI.Soup {
 			get { return this.message.response_headers; }
 		}
 
-		private OutputStream _body = null;
-
-		public override OutputStream body {
-			get {
-				if (this._body != null)
-					return this._body;
-
-				this.write_status_line ();
-
-				this.write_headers ();
-
-				this._body = output_stream;
-
-				if (this.headers.get_encoding () == Encoding.CHUNKED)
-					this._body = new ChunkedOutputStream (output_stream);
-
-				return this._body;
-			}
-		}
-
 		public Response (Request req, Message msg, OutputStream output_stream) {
 			Object (request: req, message: msg, output_stream: output_stream);
 		}

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -52,8 +52,8 @@ namespace VSGI.Soup {
 			get { return this.message.response_headers; }
 		}
 
-		public Response (Request req, Message msg, OutputStream output_stream) {
-			Object (request: req, message: msg, output_stream: output_stream);
+		public Response (Request req, Message msg, OutputStream raw_body) {
+			Object (request: req, message: msg, raw_body: raw_body);
 		}
 	}
 
@@ -114,8 +114,6 @@ namespace VSGI.Soup {
 
 				var req = new Request (msg, new MemoryInputStream.from_data (msg.request_body.data, null), query);
 				var res = new Response (req, msg, connection.output_stream);
-
-				res.headers.append ("Transfer-Encoding", "chunked");
 
 				res.end.connect_after (() => {
 					connection.close_async (Priority.DEFAULT, null, () => {

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -2,6 +2,8 @@ using Soup;
 
 /**
  * Soup implementation of VSGI.
+ *
+ * @since 0.1
  */
 namespace VSGI.Soup {
 
@@ -10,11 +12,11 @@ namespace VSGI.Soup {
 	 */
 	class Request : VSGI.Request {
 
-		public Message message { construct; get; }
-
 		private HashTable<string, string>? _query;
 
 		public override HTTPVersion http_version { get { return this.message.http_version; } }
+
+		public Message message { construct; get; }
 
 		public override string method { owned get { return this.message.method ; } }
 
@@ -28,37 +30,9 @@ namespace VSGI.Soup {
 			}
 		}
 
-		public Request (Message msg, HashTable<string, string>? query) {
-			Object (message: msg);
+		public Request (Message msg, InputStream body, HashTable<string, string>? query) {
+			Object (message: msg, body: body);
 			this._query = query;
-		}
-
-		/**
-		 * Offset from which the response body is being read.
-		 */
-		private int64 offset = 0;
-
-		public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) {
-			var chunk = this.message.request_body.get_chunk (offset);
-
-			/* potentially more data... */
-			if (chunk == null)
-				return -1;
-
-			// copy the data into the buffer
-			Memory.copy (buffer, chunk.data, chunk.length);
-
-			offset += chunk.length;
-
-			return (ssize_t) chunk.length;
-		}
-
-		/**
-		 * This will complete the request MessageBody.
-		 */
-		public override bool close (Cancellable? cancellable = null) {
-			this.message.request_body.complete ();
-			return true;
 		}
 	}
 
@@ -78,23 +52,28 @@ namespace VSGI.Soup {
 			get { return this.message.response_headers; }
 		}
 
-		public Response (Request req, Message msg) {
-			Object (request: req, message: msg);
+		private OutputStream _body = null;
+
+		public override OutputStream body {
+			get {
+				if (this._body != null)
+					return this._body;
+
+				this.write_status_line ();
+
+				this.write_headers ();
+
+				this._body = output_stream;
+
+				if (this.headers.get_encoding () == Encoding.CHUNKED)
+					this._body = new ChunkedOutputStream (output_stream);
+
+				return this._body;
+			}
 		}
 
-		public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) {
-			this.message.response_body.append_take (buffer);
-			return buffer.length;
-		}
-
-		/**
-		 * This will complete the response MessageBody.
-		 *
-		 * Once called, you will not be able to alter the stream.
-		 */
-		public override bool close (Cancellable? cancellable = null) {
-			this.message.response_body.complete ();
-			return true;
+		public Response (Request req, Message msg, OutputStream output_stream) {
+			Object (request: req, message: msg, output_stream: output_stream);
 		}
 	}
 
@@ -151,14 +130,21 @@ namespace VSGI.Soup {
 			this.server.add_handler (null, (server, msg, path, query, client) => {
 				this.hold ();
 
-				var req = new Request (msg, query);
-				var res = new Response (req, msg);
+				var connection = client.steal_connection ();
+
+				var req = new Request (msg, new MemoryInputStream.from_data (msg.request_body.data, null), query);
+				var res = new Response (req, msg, connection.output_stream);
+
+				res.headers.append ("Transfer-Encoding", "chunked");
+
+				res.end.connect_after (() => {
+					connection.close_async (Priority.DEFAULT, null, () => {
+						message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
+						this.release ();
+					});
+				});
 
 				this.application.handle (req, res);
-
-				message ("%s: %u %s %s", this.get_application_id (), res.status, req.method, req.uri.get_path ());
-
-				this.release ();
 			});
 
 #if SOUP_2_48

--- a/tests/vsgi/test.vala
+++ b/tests/vsgi/test.vala
@@ -30,6 +30,7 @@ namespace VSGI.Test {
 		}
 
 		public Request (string method, URI uri, HashTable<string, string>? query = null) {
+			Object (body: null);
 			this._method = method;
 			this._uri    = uri;
 			this._query  = query;
@@ -45,14 +46,6 @@ namespace VSGI.Test {
 
 		public Request.with_query (HashTable<string, string>? query) {
 			this._query = query;
-		}
-
-		public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) {
-			return 0;
-		}
-
-		public override bool close (Cancellable? cancellable = null) {
-			return true;
 		}
 	}
 
@@ -73,16 +66,8 @@ namespace VSGI.Test {
 		}
 
 		public Response (Request req, uint status) {
-			Object (request: req);
+			Object (request: req, body: null);
 			this._status = status;
-		}
-
-		public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) {
-			return 0;
-		}
-
-		public override bool close (Cancellable? cancellable = null) {
-			return true;
 		}
 	}
 }


### PR DESCRIPTION
The purpose of setting a Request or Response body is to wrap the stream with a
filter. This can be used to provide on-the-fly compression or encoding.