### PR TITLE
WIP: Ends in a continuation instead of a signal in Response.

### DIFF
--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -326,4 +326,4 @@ app.status (Soup.Status.NOT_FOUND, (req, res, end) => {
 	end ();
 });
 
-new Server (app).run ({"app", "--port", "3003"});
+new Server (app.handle).run ({"app", "--port", "3003"});

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -10,55 +10,42 @@ mcd.add_server ("127.0.0.1", 11211);
 // extra route types
 app.types["permutations"] = /abc|acb|bac|bca|cab|cba/;
 
-app.get ("<any:any>", (req, res, next) => {
-	var timer  = new Timer ();
-
-	res.end.connect (() => {
-		timer.stop ();
-		var elapsed = timer.elapsed ();
-		res.headers.append ("X-Runtime", "%8.3fms".printf (elapsed * 1000));
-		message ("%s computed in %8.3fms", req.uri.get_path (), elapsed * 1000);
-	});
-
-	timer.start ();
-
-	next ();
-});
-
 // default route
-app.get ("", (req, res) => {
+app.get ("", (req, res, end) => {
 	var template = new View.from_stream (resources_open_stream ("/templates/home.html", ResourceLookupFlags.NONE));
-
 	template.stream (res.body);
-	res.end ();
+
+	res.body.close ();
+
+	end ();
 });
 
 app.methods ({VSGI.Request.GET, VSGI.Request.POST}, "get-and-post", (req, res) => {
 	res.body.write ("Matches GET and POST".data);
 });
 
-app.all (null, (req, res, next) => {
+app.all (null, (req, res, end, next) => {
 	res.headers.append ("Server", "Valum/1.0");
 	next ();
 });
 
-app.all ("all", (req, res) => {
+app.all ("all", (req, res, end) => {
 	res.body.write ("Matches all HTTP methods".data);
-	res.end ();
+	end ();
 });
 
 // default route
-app.get ("gzip", (req, res) => {
+app.get ("gzip", (req, res, end) => {
 	var template = new View.from_stream (resources_open_stream ("/templates/home.html", ResourceLookupFlags.NONE));
 
 	res.headers.append ("Content-Encoding", "gzip");
 	res.body = new ConverterOutputStream (res.body, new ZlibCompressor (ZlibCompressorFormat.GZIP));
 
 	template.stream (res.body);
-	res.end ();
+	end ();
 });
 
-app.get ("query", (req, res) => {
+app.get ("query", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
@@ -69,10 +56,10 @@ app.get ("query", (req, res) => {
 		});
 	}
 
-	res.end ();
+	end ();
 });
 
-app.get ("headers", (req, res) => {
+app.get ("headers", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
@@ -81,10 +68,10 @@ app.get ("headers", (req, res) => {
 		writer.put_string ("%s: %s\n".printf (name, header));
 	});
 
-	res.end ();
+	end ();
 });
 
-app.get ("cookies", (req, res) => {
+app.get ("cookies", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 
 	res.headers.set_content_type ("text/plain", null);
@@ -95,41 +82,41 @@ app.get ("cookies", (req, res) => {
 		writer.put_string ("%s: %s\n".printf (cookie.name, cookie.value));
 	}
 
-	res.end ();
+	end ();
 });
 
-app.get ("custom-route-type/<permutations:p>", (req, res) => {
+app.get ("custom-route-type/<permutations:p>", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string (req.params["p"]);
-	res.end ();
+	end ();
 });
 
 // hello world! (compare with Node.js!)
-app.get ("hello", (req, res) => {
+app.get ("hello", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("Hello world\n");
-	res.end ();
+	end ();
 });
 
 // hello with a trailing slash
-app.get ("hello/", (req, res) => {
+app.get ("hello/", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("Hello world\n");
-	res.end ();
+	end ();
 });
 
 // example using route parameter
-app.get ("hello/<id>", (req, res) => {
+app.get ("hello/<id>", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	res.headers.set_content_type ("text/plain", null);
 	writer.put_string ("hello %s!".printf (req.params["id"]));
-	res.end ();
+	end ();
 });
 
 app.scope ("urlencoded-data", (inner) => {
-	inner.get ("", (req, res) => {
+	inner.get ("", (req, res, end) => {
 		var writer = new DataOutputStream (res.body);
 		writer.put_string (
 		"""
@@ -143,10 +130,10 @@ app.scope ("urlencoded-data", (inner) => {
 		  </body>
 		</html>
 		""");
-		res.end ();
+		end ();
 	});
 
-	inner.post ("", (req, res) => {
+	inner.post ("", (req, res, end) => {
 		var writer = new DataOutputStream (res.body);
 		var data   = new MemoryOutputStream (null, realloc, free);
 
@@ -156,12 +143,12 @@ app.scope ("urlencoded-data", (inner) => {
 			writer.put_string ("%s: %s".printf (k, v));
 		});
 
-		res.end ();
+		end ();
 	});
 });
 
 // example using a typed route parameter
-app.get ("users/<int:id>/<action>", (req, res) => {
+app.get ("users/<int:id>/<action>", (req, res, end) => {
 	var id     = req.params["id"];
 	var test   = req.params["action"];
 	var writer = new DataOutputStream (res.body);
@@ -171,11 +158,11 @@ app.get ("users/<int:id>/<action>", (req, res) => {
 	writer.put_string (@"id\t=> $id\n");
 	writer.put_string (@"action\t=> $test");
 
-	res.end ();
+	end ();
 });
 
 // lua scripting
-app.get ("lua", (req, res) => {
+app.get ("lua", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string (lua.eval ("""
 		require "markdown"
@@ -184,18 +171,18 @@ app.get ("lua", (req, res) => {
 
 	writer.put_string (lua.run ("examples/app/hello.lua"));
 
-	res.end ();
+	end ();
 });
 
-app.get ("lua.haml", (req, res) => {
+app.get ("lua.haml", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string (lua.run ("examples/app/haml.lua"));
-	res.end ();
+	end ();
 });
 
 
 // Ctpl template rendering
-app.get ("ctpl/<foo>/<bar>", (req, res) => {
+app.get ("ctpl/<foo>/<bar>", (req, res, end) => {
 	var tpl = new View.from_string ("""
 	   <p>hello {foo}</p>
 	   <p>hello {bar}</p>
@@ -212,26 +199,26 @@ app.get ("ctpl/<foo>/<bar>", (req, res) => {
 	tpl.push_int ("int", 1);
 
 	tpl.stream (res.body);
-	res.end ();
+	end ();
 });
 
 // memcached
-app.get ("memcached/get/<key>", (req, res) => {
+app.get ("memcached/get/<key>", (req, res, end) => {
 	var value = mcd.get (req.params["key"]);
 	var writer = new DataOutputStream (res.body);
 	writer.put_string (value);
-	res.end ();
+	end ();
 });
 
 // TODO: rewrite using POST
-app.get ("memcached/set/<key>/<value>", (req, res) => {
+app.get ("memcached/set/<key>/<value>", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	if (mcd.set (req.params["key"], req.params["value"])) {
 		writer.put_string ("Ok! Pushed.");
 	} else {
 		writer.put_string ("Fail! Not Pushed...");
 	}
-	res.end ();
+	end ();
 });
 
 // scoped routing
@@ -239,34 +226,34 @@ app.scope ("admin", (adm) => {
 	// matches /admin/fun
 	adm.scope ("fun", (fun) => {
 		// matches /admin/fun/hack
-		fun.get ("hack", (req, res) => {
+		fun.get ("hack", (req, res, end) => {
 			var time = new DateTime.now_utc ();
 			var writer = new DataOutputStream (res.body);
 			res.headers.set_content_type ("text/plain", null);
 			writer.put_string ("It's %s around here!\n".printf (time.format ("%H:%M")));
-			res.end ();
+			end ();
 		});
 		// matches /admin/fun/heck
-		fun.get ("heck", (req, res) => {
+		fun.get ("heck", (req, res, end) => {
 			var writer = new DataOutputStream (res.body);
 			res.headers.set_content_type ("text/plain", null);
 			writer.put_string ("Wuzzup!");
-			res.end ();
+			end ();
 		});
 	});
 });
 
-app.get ("next", (req, res, next) => {
+app.get ("next", (req, res, end, next) => {
 	next ();
 });
 
-app.get ("next", (req, res) => {
+app.get ("next", (req, res, end) => {
 	res.body.write ("Matched by the next route in the queue.".data);
-	res.end ();
+	end ();
 });
 
 // serve static resource using a path route parameter
-app.get ("static/<path:resource>.<any:type>", (req, res) => {
+app.get ("static/<path:resource>.<any:type>", (req, res, end) => {
 	var resource = req.params["resource"];
 	var type     = req.params["type"];
 	var contents = new uint8[128];
@@ -287,55 +274,56 @@ app.get ("static/<path:resource>.<any:type>", (req, res) => {
 		// transfer the file
 		res.body.splice_async.begin (file, OutputStreamSpliceFlags.CLOSE_SOURCE, Priority.DEFAULT, null, (obj, result) => {
 			var size = res.body.splice_async.end (result);
-			res.end ();
+			end ();
 		});
 	} catch (Error e) {
 		throw new ClientError.NOT_FOUND (e.message);
 	}
 });
 
-app.get ("redirect", (req, res) => {
+app.get ("redirect", (req, res, end) => {
 	throw new Redirection.MOVED_TEMPORARILY ("http://example.com");
 });
 
-app.get ("not-found", (req, res) => {
+app.get ("not-found", (req, res, end) => {
 	throw new ClientError.NOT_FOUND ("the given URL was not found");
 });
 
-app.method (VSGI.Request.GET, "custom-method", (req, res) => {
+app.method (VSGI.Request.GET, "custom-method", (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string (req.method);
-	res.end ();
+	end ();
 });
 
-app.regex (VSGI.Request.GET, /custom-regular-expression/, (req, res) => {
+app.regex (VSGI.Request.GET, /custom-regular-expression/, (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string ("This route was matched using a custom regular expression.");
-	res.end ();
+	end ();
 });
 
-app.matcher (VSGI.Request.GET, (req) => { return req.uri.get_path () == "/custom-matcher"; }, (req, res) => {
+app.matcher (VSGI.Request.GET, (req) => { return req.uri.get_path () == "/custom-matcher"; }, (req, res, end) => {
 	var writer = new DataOutputStream (res.body);
 	writer.put_string ("This route was matched using a custom matcher.");
-	res.end ();
+	end ();
 });
 
 var api = new Router ();
 
-api.get ("repository/<name>", (req, res) => {
+api.get ("repository/<name>", (req, res, end) => {
 	var name = req.params["name"];
 	res.body.write (name.data);
-	res.end ();
+	end ();
 });
 
 // delegate all other GET requests to a subrouter
 app.get ("<any:path>", api.handle);
 
-app.status (Soup.Status.NOT_FOUND, (req, res) => {
+app.status (Soup.Status.NOT_FOUND, (req, res, end) => {
 	res.status = Soup.Status.NOT_FOUND;
 	var template = new View.from_stream (resources_open_stream ("/templates/404.html", ResourceLookupFlags.NONE));
 	template.environment.push_string ("path", req.uri.get_path ());
 	template.stream (res.body);
+	end ();
 });
 
 new Server (app).run ({"app", "--port", "3003"});

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -5,12 +5,12 @@ public static int main (string[] args) {
 	var app = new Router ();
 
 	// default route
-	app.get ("", (req, res) => {
+	app.get ("", (req, res, end) => {
 		res.body.write ("Hello world!".data);
-		res.end ();
+		end ();
 	});
 
-	app.get ("random/<int:size>", (req, res) => {
+	app.get ("random/<int:size>", (req, res, end) => {
 		var size   = int.parse (req.params["size"]);
 		var writer = new DataOutputStream (res.body);
 
@@ -19,16 +19,16 @@ public static int main (string[] args) {
 			writer.put_uint32 (Random.next_int ());
 		}
 
-		res.end ();
+		end ();
 	});
 
-	app.get ("<any:path>", (req, res) => {
+	app.get ("<any:path>", (req, res, end) => {
 		res.status = 404;
 
 		var writer = new DataOutputStream (res.body);
 		writer.put_string ("404 - Not found");
 
-		res.end ();
+		end ();
 	});
 
 	return new Server (app).run (args);

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -31,5 +31,5 @@ public static int main (string[] args) {
 		end ();
 	});
 
-	return new Server (app).run (args);
+	return new Server (app.handle).run (args);
 }

--- a/src/route.vala
+++ b/src/route.vala
@@ -49,7 +49,7 @@ namespace Valum {
 		 * @param end  end
 		 * @param next keep routing
 		 */
-		public delegate void HandlerCallback (Request req, Response res, VSGI.Application.EndCallback end, Router.NextCallback next) throws Redirection, ClientError, ServerError;
+		public delegate void HandlerCallback (Request req, Response res, VSGI.EndCallback end, Router.NextCallback next) throws Redirection, ClientError, ServerError;
 
 		/**
 		 * Create a Route using a custom matcher.

--- a/src/route.vala
+++ b/src/route.vala
@@ -44,10 +44,12 @@ namespace Valum {
 		 * @throws ClientError trigger a 4xx client error
 		 * @throws ServerError trigger a 5xx server error
 		 *
-		 * @param req request being handled
-		 * @param res response to send back to the requester
+		 * @param req  request being handled
+		 * @param res  response to send back to the requester
+		 * @param end  end
+		 * @param next keep routing
 		 */
-		public delegate void HandlerCallback (Request req, Response res, Router.NextCallback next) throws Redirection, ClientError, ServerError;
+		public delegate void HandlerCallback (Request req, Response res, VSGI.Application.EndCallback end, Router.NextCallback next) throws Redirection, ClientError, ServerError;
 
 		/**
 		 * Create a Route using a custom matcher.

--- a/src/router.vala
+++ b/src/router.vala
@@ -9,7 +9,7 @@ namespace Valum {
 	 *
 	 * @since 0.0.1
 	 */
-	public class Router : Object, VSGI.Application {
+	public class Router : Object {
 
 		/**
 		 * Registered types used to extract {@link VSGI.Request} parameters.
@@ -254,7 +254,7 @@ namespace Valum {
 		 * @param res
 		 * @return tells if something matched during the routing process
 		 */
-		private bool perform_routing (List<Route> routes, Request req, Response res, VSGI.Application.EndCallback end) throws Redirection, ClientError, ServerError {
+		private bool perform_routing (List<Route> routes, Request req, Response res, VSGI.EndCallback end) throws Redirection, ClientError, ServerError {
 			foreach (var route in routes) {
 				if (route.match (req)) {
 					route.fire (req, res, end, () => {
@@ -278,7 +278,7 @@ namespace Valum {
 		 * code, 'text/html' content type, 'chunked' transfer encoding and
 		 * request cookies.
 		 */
-		public void handle (Request req, Response res, VSGI.Application.EndCallback end) {
+		public void handle (Request req, Response res, VSGI.EndCallback end) {
 			// sane initialization
 			res.status = Soup.Status.OK;
 			res.headers.set_content_type ("text/html", null);

--- a/src/vsgi/application.vala
+++ b/src/vsgi/application.vala
@@ -11,6 +11,7 @@ using GLib;
  */
 [CCode (gir_namespace = "VSGI", gir_version = "0.1")]
 namespace VSGI {
+
 	/**
 	 * Application that handles a pair of {@link VSGI.Request} and
 	 * {@link VSGI.Response}.
@@ -20,17 +21,24 @@ namespace VSGI {
 	public interface Application : Object {
 
 		/**
-		 * Process a pair of request and response.
+		 * End the processing of the {@link VSGI.Application}.
 		 *
-		 * Blocks until the response have been fully processed.
+		 * This delegate is generally provided by the server implementation to free
+		 * resources related to a client request.
+		 *
+		 * @since 0.2
+		 */
+		public delegate void EndCallback ();
+
+		/**
+		 * Process a pair of request and response.
 		 *
 		 * @since 0.1
 		 *
-		 * @param req request providen to the application by a
-		 *            {@link VSGI.Server}
-		 * @param res response where the application should produce its output
-		 * @param end called to end the processing of the response
+		 * @param req request representing a request resource
+		 * @param res response
+		 * @param end end the processing of the client request
 		 */
-		public abstract void handle (Request req, Response res);
+		public abstract void handle (Request req, Response res, EndCallback end);
 	}
 }

--- a/src/vsgi/application.vala
+++ b/src/vsgi/application.vala
@@ -4,7 +4,7 @@ using GLib;
  * VSGI is an set of abstraction and implementations used to build generic web
  * application in Vala.
  *
- * It is minimalist and relies on libsoup, a good and stable HTTP library.
+ * It is minimalist and relies on libsoup-2.4, a good and stable HTTP library.
  *
  * Two implementation are available: libsoup built-in Soup.Server and FastCGI.
  * The latter integrates with pretty much any web server.
@@ -13,32 +13,28 @@ using GLib;
 namespace VSGI {
 
 	/**
-	 * Application that handles a pair of {@link VSGI.Request} and
-	 * {@link VSGI.Response}.
+	 * End the processing of the of a {@link VSGI.ApplicationCallback}.
 	 *
-	 * @since 0.1
+	 * This delegate define a continuation passed by the {@link VSGI.Server} to
+	 * the {@link VSGI.ApplicationCallback} to release resources related to the
+	 * request being processed when the latter finishes.
+	 *
+	 * @since 0.2
 	 */
-	public interface Application : Object {
+	public delegate void EndCallback ();
 
-		/**
-		 * End the processing of the {@link VSGI.Application}.
-		 *
-		 * This delegate is generally provided by the server implementation to free
-		 * resources related to a client request.
-		 *
-		 * @since 0.2
-		 */
-		public delegate void EndCallback ();
-
-		/**
-		 * Process a pair of request and response.
-		 *
-		 * @since 0.1
-		 *
-		 * @param req request representing a request resource
-		 * @param res response
-		 * @param end end the processing of the client request
-		 */
-		public abstract void handle (Request req, Response res, EndCallback end);
-	}
+	/**
+	 * Process a pair of {@link VSGI.Request} and {@link VSGI.Response}.
+	 *
+	 * The end continuation must be invoked when the application processing
+	 * finishes. It may be invoked in an asynchronous context even after the
+	 * callback returns to the callee.
+	 *
+	 * @since 0.2
+	 *
+	 * @param req a resource being requested
+	 * @param res the response to that request
+	 * @param end end the processing of the client request and free resources
+	 */
+	public delegate void ApplicationCallback (Request req, Response res, EndCallback end);
 }

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -265,6 +265,9 @@ namespace VSGI.FastCGI {
 		 */
 		public GLib.Socket? socket { get; set; default = null; }
 
+		/**
+		 * {@inheritDoc}
+		 */
 		public Server (ApplicationCallback application) {
 			base (application);
 

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -363,14 +363,12 @@ namespace VSGI.FastCGI {
 				var req = new Request (environment, new StreamInputStream (this.socket, request.in));
 				var res = new Response (req, new StreamOutputStream (this.socket, request.out, request.err));
 
-				res.end.connect_after (() => {
+				this.application.handle (req, res, () => {
 					request.finish ();
 					request.close (false); // keep the socket open
 					message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
 					this.release ();
 				});
-
-				this.application.handle (req, res);
 
 				return true;
 			});

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -265,7 +265,7 @@ namespace VSGI.FastCGI {
 		 */
 		public GLib.Socket? socket { get; set; default = null; }
 
-		public Server (VSGI.Application application) {
+		public Server (ApplicationCallback application) {
 			base (application);
 
 #if GIO_2_40
@@ -363,7 +363,7 @@ namespace VSGI.FastCGI {
 				var req = new Request (environment, new StreamInputStream (this.socket, request.in));
 				var res = new Response (req, new StreamOutputStream (this.socket, request.out, request.err));
 
-				this.application.handle (req, res, () => {
+				this.application (req, res, () => {
 					request.finish ();
 					request.close (false); // keep the socket open
 					message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -131,25 +131,5 @@ namespace VSGI {
 
 			return this.base_stream.write (headers.str.data);
 		}
-
-		/**
-		 * End the {@link Response} processing and notify that event to the
-		 * listeners.
-		 *
-		 * The default handler will write the status line, write the response
-		 * headers and close the request and response bodies if any of these is
-		 * not done already.
-		 *
-		 * @since 0.2
-		 */
-		public virtual signal void end () {
-			// close the request body
-			this.request.body.close ();
-
-			// close this response body
-			// accessing the body for the first time will write the status line
-			// and headers
-			this.body.close ();
-		}
 	}
 }

--- a/src/vsgi/server.vala
+++ b/src/vsgi/server.vala
@@ -1,7 +1,8 @@
 namespace VSGI {
 
 	/**
-	 * Server that feeds a {@link VSGI.Application} with incoming requests.
+	 * Server that feeds a {@link VSGI.ApplicationCallback} with incoming
+	 * requests.
 	 *
 	 * Once you have initialized a Server instance, start it by calling
 	 * {@link GLib.Application.run} with the command-line arguments or a set of
@@ -20,11 +21,11 @@ namespace VSGI {
 	public class Server : GLib.Application {
 
 		/**
-		 * Application being served.
+		 * Application being served with client requests.
 		 *
-		 * @since 0.1
+		 * @since 0.2
 		 */
-		public VSGI.Application application { construct; get; }
+		protected ApplicationCallback application;
 
 		/**
 		 * Enforces implementation to take the application as a sole argument
@@ -34,8 +35,9 @@ namespace VSGI {
 		 *
 		 * @since 0.2
 		 */
-		public Server (VSGI.Application application) {
-			Object (application: application, flags: ApplicationFlags.HANDLES_COMMAND_LINE);
+		public Server (ApplicationCallback application) {
+			Object (flags: ApplicationFlags.HANDLES_COMMAND_LINE);
+			this.application = application;
 		}
 	}
 }

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -176,7 +176,7 @@ namespace VSGI.Soup {
 				var req = new Request (msg, input_stream, query);
 				var res = new Response (req, msg, output_stream);
 
-				res.end.connect_after (() => {
+				this.application.handle (req, res, () => {
 #if SOUP_2_50
 					connection.close_async.begin (Priority.DEFAULT, null, () => {
 						message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
@@ -188,8 +188,6 @@ namespace VSGI.Soup {
 					this.release ();
 #endif
 				});
-
-				this.application.handle (req, res);
 			});
 
 #if SOUP_2_48

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -164,30 +164,35 @@ namespace VSGI.Soup {
 			this.server.add_handler (null, (server, msg, path, query, client) => {
 				this.hold ();
 
+				// at this point, the request is already consumed, so we provide
+				// a simple stream over the data.
 				var input_stream  = new MemoryInputStream.from_data (msg.request_body.data, null);
 
 #if SOUP_2_50
 				var connection = client.steal_connection ();
-				var output_stream = connection.output_stream;
 #else
-				var output_stream = new MemoryOutputStream (msg.response_body.data, realloc, free);
+				var connection = new SimpleIOStream (input_stream,
+				                                     new MemoryOutputStream (msg.response_body.data, realloc, free));
 #endif
 
 				var req = new Request (msg, input_stream, query);
-				var res = new Response (req, msg, output_stream);
+				var res = new Response (req, msg, connection.output_stream);
 
 				this.application (req, res, () => {
-#if SOUP_2_50
+#if !SOUP_2_50
+					// resume I/O operations
+					this.server.unpause_message (msg);
+#endif
 					connection.close_async.begin (Priority.DEFAULT, null, () => {
 						message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
 						this.release ();
 					});
-#else
-					msg.response_body.complete ();
-					message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());
-					this.release ();
-#endif
 				});
+
+#if !SOUP_2_50
+				// prevent the server from completing the message on return
+				this.server.pause_message (msg);
+#endif
 			});
 
 #if SOUP_2_48

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -122,7 +122,7 @@ namespace VSGI.Soup {
 		/**
 		 * {@inheritDoc}
 		 */
-		public Server (VSGI.Application application) {
+		public Server (ApplicationCallback application) {
 			base (application);
 
 #if GIO_2_40
@@ -176,7 +176,7 @@ namespace VSGI.Soup {
 				var req = new Request (msg, input_stream, query);
 				var res = new Response (req, msg, output_stream);
 
-				this.application.handle (req, res, () => {
+				this.application (req, res, () => {
 #if SOUP_2_50
 					connection.close_async.begin (Priority.DEFAULT, null, () => {
 						message ("%s: %u %s %s", get_application_id (), res.status, res.request.method, res.request.uri.get_path ());

--- a/tests/test_route.vala
+++ b/tests/test_route.vala
@@ -162,7 +162,7 @@ public void test_route_fire () {
 
 	assert (setted == false);
 
-	route.fire (req, res, () => {});
+	route.fire (req, res, () => {}, () => {});
 
 	assert (setted);
 }

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -27,7 +27,7 @@ public static void test_router_get () {
 	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -45,7 +45,7 @@ public static void test_router_post () {
 	var request  = new Request (VSGI.Request.POST, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -63,7 +63,7 @@ public static void test_router_put () {
 	var request  = new Request (VSGI.Request.PUT, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -81,7 +81,7 @@ public static void test_router_delete () {
 	var request  = new Request (VSGI.Request.DELETE, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -99,7 +99,7 @@ public static void test_router_head () {
 	var request  = new Request (VSGI.Request.HEAD, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -117,7 +117,7 @@ public static void test_router_options () {
 	var request  = new Request (VSGI.Request.OPTIONS, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -135,7 +135,7 @@ public static void test_router_trace () {
 	var request  = new Request (VSGI.Request.TRACE, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -153,7 +153,7 @@ public static void test_router_connect () {
 	var request  = new Request (VSGI.Request.CONNECT, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -170,7 +170,7 @@ public static void test_router_patch () {
 	var request  = new Request (VSGI.Request.PATCH, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -191,7 +191,7 @@ public static void test_router_methods () {
 		var request  = new Request (method, new Soup.URI ("http://localhost/"));
 		var response = new Response (request, Soup.Status.OK);
 
-		router.handle (request, response);
+		router.handle (request, response, () => {});
 
 		assert (418 == response.status);
 	}
@@ -211,7 +211,7 @@ public static void test_router_all () {
 		var request  = new Request (method, new Soup.URI ("http://localhost/"));
 		var response = new Response (request, Soup.Status.OK);
 
-		router.handle (request, response);
+		router.handle (request, response, () => {});
 
 		assert (418 == response.status);
 	}
@@ -230,7 +230,7 @@ public static void test_router_regex () {
 	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/home"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -248,7 +248,7 @@ public static void test_router_matcher () {
 	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -268,7 +268,7 @@ public static void test_router_scope () {
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/test/test"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (response.status == 418);
 }
@@ -286,7 +286,7 @@ public static void test_router_redirection () {
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (response.status == Soup.Status.MOVED_TEMPORARILY);
 	assert ("http://example.com" == response.headers.get_one ("Location"));
@@ -302,7 +302,7 @@ public static void test_router_server_error () {
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (response.status == Soup.Status.INTERNAL_SERVER_ERROR);
 }
@@ -320,7 +320,7 @@ public static void test_router_custom_method () {
 	var request = new Request ("TEST", new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (response.status == 418);
 }
@@ -342,7 +342,7 @@ public static void test_router_method_not_allowed () {
 	var request = new Request ("POST", new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.METHOD_NOT_ALLOWED);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (response.status == 405);
 	assert ("PUT, GET" == response.headers.get_one ("Allow"));
@@ -370,7 +370,7 @@ public static void test_router_method_not_allowed_excludes_request_method () {
 	var request = new Request ("POST", new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.METHOD_NOT_ALLOWED);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (post_matched == 1); // matched only once during initial lookup
 	assert (get_matched == 1);
@@ -388,7 +388,7 @@ public static void test_router_not_found () {
 	var request = new Request ("GET", new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (Soup.Status.NOT_FOUND == response.status);
 }
@@ -409,7 +409,7 @@ public static void test_router_subrouting () {
 	var request = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.NOT_FOUND);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -420,23 +420,24 @@ public static void test_router_subrouting () {
 public static void test_router_next () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
 	// should recurse a bit in process_routing
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end) => {
 		res.status = 418;
+		end ();
 	});
 
 	var request = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.NOT_FOUND);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (418 == response.status);
 }
@@ -444,12 +445,12 @@ public static void test_router_next () {
 public static void test_router_next_not_found () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
 	// should recurse a bit in process_routing
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
@@ -458,7 +459,7 @@ public static void test_router_next_not_found () {
 	var request = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (404 == response.status);
 }
@@ -469,22 +470,22 @@ public static void test_router_next_not_found () {
 public static void test_router_next_propagate_error () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end, next) => {
 		next ();
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("", (req, res, end) => {
 		throw new ClientError.UNAUTHORIZED ("");
 	});
 
-	var request = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
 	var response = new Response (request, Soup.Status.OK);
 
-	router.handle (request, response);
+	router.handle (request, response, () => {});
 
 	assert (401 == response.status);
 }


### PR DESCRIPTION
Moves the Response end signal in a continuation passed in Application handle
function.

Adapts the routing to pass the end continuation over process_routing.

Updates examples to take the third argument end and call it instead of res.end.

Updates tests to take that change into consideration when invoking
Router.handle.

The new approach look like this:

```vala
app.get ("", (req, res, end, next) => {
    next ();
});

app.get ("", (req, res, end) => {
    res.body.write ("Hello world!".data);
    end ();
});
```