### PR TITLE
Status code handler.

### DIFF
--- a/docs/redirection-and-error.rst
+++ b/docs/redirection-and-error.rst
@@ -10,14 +10,35 @@ In a :doc:`route` callback, you may throw any of ``Redirection``,
 ``ClientError`` and ``ServerError`` predefined error domains rather than
 setting the status and returning from the function.
 
-The :doc:`router` handler will automatically catch these special errors and set
-the appropriate status code in the response for your convenience.
+It is possible to connect a callback on the :doc:`router` to handle a specific
+status code. Otherwise, the router will simply set the status code in the
+response and set headers for specific errors.
+
+.. code:: vala
+
+    app.status (Soup.Status.PERMANENT, (req, res) => {
+        res.status = Soup.Status.PERMANENT;
+    });
+
+The error message may be used to fill specific :doc:`vsgi/response` headers.
+The following table describe how the router deal with specific error messages.
+
++--------------------------------+----------+
+| Error                          | Header   |
++================================+==========+
+| Redirection.*                  | Location |
++--------------------------------+----------+
+| ClientError.METHOD_NOT_ALLOWED | Accept   |
++--------------------------------+----------+
 
 Redirection (3xx)
 -----------------
 
 To perform a redirection, you have to throw a ``Redirection`` error and use the
-message as a redirect URL.
+message as a redirect URL. The :doc:`router` will automatically set the
+``Location`` header accordingly.
+
+Redirections are enumerated in ``Redirection`` enumeration.
 
 .. code:: vala
 
@@ -31,9 +52,8 @@ message as a redirect URL.
 Client (4xx) and server (5xx) error
 -----------------------------------
 
-Just like for redirection, client and server errors are thrown.
-
-Errors are predefined in ``ClientError`` and ``ServerError`` enumerations.
+Like for redirections, client and server errors are thrown. Errors are
+predefined in ``ClientError`` and ``ServerError`` enumerations.
 
 .. code:: vala
 
@@ -55,18 +75,4 @@ the :doc:`router` can handle them properly.
 
     app.get ("", (req, res) => {
         throw new ClientError.NOT_FOUND ("");
-    });
-
-Custom handling for status
---------------------------
-
-To do custom handling for specific status, bind a callback to the ``teardown``
-signal, it is executed after the processing of a client request.
-
-.. code:: vala
-
-    app.teardown.connect ((req, res) => {
-        if (res.status == Soup.Status.NOT_FOUND) {
-            // produce a 404 page...
-        }
     });

--- a/docs/router.rst
+++ b/docs/router.rst
@@ -94,6 +94,50 @@ otherwise you will experience inconsistencies.
         // matches /home
     });
 
+Status handling
+---------------
+
+Thrown status code can be handled by a :doc:`route` handler callback.
+
+The received :doc:`vsgi/request` and :doc:`vsgi/response` object are in the
+same state they were when the status was thrown, except for the request
+parameters that contains two additional keys:
+
+-  ``code`` for the status code
+-  ``message`` for the status message
+
+.. _GLib.Error
+
+.. code:: vala
+
+    app.status (Soup.Status.NOT_FOUND, (req, res) => {
+        // produce a 404 page...
+    });
+
+Similarly to conventional request handling, the ``next`` continuation can be
+invoked to jump to the next status handler in the queue.
+
+.. code:: vala
+
+    app.status (Soup.Status.NOT_FOUND, (req, res, next) => {
+        next ();
+    });
+
+    app.status (Soup.Status.NOT_FOUND, (req, res) => {
+        res.status = 404;
+        res.body.write ("Not found!".data);
+    });
+
+:doc:`redirection-and-error` can be thrown during the status handling, they
+will be caught by the ``Router`` and processed accordingly.
+
+.. code:: vala
+
+    // turns any 404 into a permanent redirection
+    app.status (Soup.Status.NOT_FOUND, (req, res) => {
+        throw new Redirection.PERMANENT ("http://example.com");
+    });
+
 Scoping
 -------
 
@@ -167,3 +211,4 @@ matching route.
     app.get ("", (req, res) => {
         // this is invoked!
     });
+

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -269,12 +269,11 @@ api.get ("repository/<name>", (req, res) => {
 // delegate all other GET requests to a subrouter
 app.get ("<any:path>", api.handle);
 
-app.teardown.connect ((req, res) => {
-	if (res.status == 404) {
-		var template = new View.from_stream (resources_open_stream ("/templates/404.html", ResourceLookupFlags.NONE));
-		template.environment.push_string ("path", req.uri.get_path ());
-		template.stream (res);
-	}
+app.status (Soup.Status.NOT_FOUND, (req, res) => {
+	res.status = Soup.Status.NOT_FOUND;
+	var template = new View.from_stream (resources_open_stream ("/templates/404.html", ResourceLookupFlags.NONE));
+	template.environment.push_string ("path", req.uri.get_path ());
+	template.stream (res);
 });
 
 new Server (app).run ({"app", "--port", "3003"});

--- a/src/router.vala
+++ b/src/router.vala
@@ -324,6 +324,13 @@ namespace Valum {
 					throw new ClientError.NOT_FOUND ("The request URI %s was not found.".printf (req.uri.to_string (false)));
 
 				} catch (Error e) {
+					if (req.params == null)
+						req.params = new HashTable<string, string> (str_hash, str_equal);
+
+					// provide additionnal information through request parameters
+					req.params["code"]    = e.code.to_string ();
+					req.params["message"] = e.message;
+
 					// handle using a registered status handler
 					if (this.status_handlers.contains (e.code)) {
 						if (this.perform_routing (this.status_handlers[e.code].head, req, res))


### PR DESCRIPTION
The status handler is invoked with perform_routing, so next can be used to jump
to the next status handler for a given status. If nothing matches, the router
handler is used.

The great thing about this implementation is that it reuses `perform_routing` and fallbacks on `Router` default handling if a status is not handled.