### PR TITLE
Route with a null rule will catch all request paths.

### DIFF
--- a/docs/route.rst
+++ b/docs/route.rst
@@ -72,6 +72,22 @@ These will respectively compile down to the following regular expressions
 -  ``^/user/(?<id>\w+)$``
 -  ``^/user/(?<id>\d+)$``
 
+Null rule
+~~~~~~~~~
+
+The ``null`` rule will be replaced by the catch-all rule: ``<any:path``. It can
+be used to implement setup operations.
+
+.. code:: vala
+
+    app.get (null, (req, res, next) => {
+        // always invoked!
+    });
+
+    app.get ("", (req, res) => {
+        //
+    });
+
 Types
 ~~~~~
 

--- a/docs/router.rst
+++ b/docs/router.rst
@@ -15,6 +15,10 @@ Callback can be connected to HTTP methods via a list of helpers having the
 
     app.get ("rule", (req, res) => {});
 
+The rule has to respect the rule syntax described in :doc:`route`. It will be
+compiled down to a regex which named groups are made accessible through
+:doc:`vsgi/request` parameters.
+
 Helpers for the HTTP/1.1 protocol and the extra ``TRACE`` methods are included.
 
 -  ``get``

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -21,6 +21,11 @@ app.methods ({VSGI.Request.GET, VSGI.Request.POST}, "get-and-post", (req, res) =
 	res.write ("Matches GET and POST".data);
 });
 
+app.all (null, (req, res, next) => {
+	res.headers.append ("Server", "Valum/1.0");
+	next ();
+});
+
 app.all ("all", (req, res) => {
 	res.write ("Matches all HTTP methods".data);
 });

--- a/src/route.vala
+++ b/src/route.vala
@@ -137,13 +137,16 @@ namespace Valum {
 		 * path.
 		 *
 		 * @since 0.0.1
+		 *
+		 * @param router
+		 * @param rule   defaults to "<any:path>" if set to null
 		 */
-		public Route.from_rule (Router router, string rule, HandlerCallback callback) throws RegexError {
+		public Route.from_rule (Router router, string? rule, HandlerCallback callback) throws RegexError {
 			this.router   = router;
 			this.fire     = callback;
 
 			var param_regex = new Regex ("(<(?:\\w+:)?\\w+>)");
-			var params      = param_regex.split_full (rule);
+			var params      = param_regex.split_full (rule == null ? "<any:path>" : rule);
 			var captures    = new SList<string> ();
 			var route       = new StringBuilder ("^");
 

--- a/src/router.vala
+++ b/src/router.vala
@@ -75,56 +75,56 @@ namespace Valum {
 		/**
 		 * @since 0.0.1
 		 */
-		public new void get (string rule, Route.HandlerCallback cb) throws RegexError {
+		public new void get (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.GET, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void post (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void post (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.POST, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void put (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void put (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.PUT, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void delete (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void delete (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.DELETE, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void head (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void head (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.HEAD, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void options(string rule, Route.HandlerCallback cb) throws RegexError {
+		public void options(string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.OPTIONS, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void trace (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void trace (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.TRACE, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public new void connect (string rule, Route.HandlerCallback cb) throws RegexError {
+		public new void connect (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.CONNECT, rule, cb);
 		}
 
@@ -133,7 +133,7 @@ namespace Valum {
 		 *
 		 * @since 0.0.1
 		 */
-		public void patch (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void patch (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.method (Request.PATCH, rule, cb);
 		}
 
@@ -149,7 +149,7 @@ namespace Valum {
 		 * @param rule   rule
 		 * @param cb     callback used to process the pair of request and response.
 		 */
-		public void method (string method, string rule, Route.HandlerCallback cb) throws RegexError {
+		public void method (string method, string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.route (method, new Route.from_rule (this, rule, cb));
 		}
 
@@ -159,7 +159,7 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public void all (string rule, Route.HandlerCallback cb) throws RegexError {
+		public void all (string? rule, Route.HandlerCallback cb) throws RegexError {
 			this.methods (Request.METHODS, rule, cb);
 		}
 
@@ -171,7 +171,7 @@ namespace Valum {
 		 * @param methods methods to which the callback will be bound
 		 * @param rule    rule
 		 */
-		public void methods (string[] methods, string rule, Route.HandlerCallback cb) {
+		public void methods (string[] methods, string? rule, Route.HandlerCallback cb) {
 			var route = new Route.from_rule (this, rule, cb);
 			foreach (var method in methods) {
 				this.route (method, route);

--- a/tests/test_route.vala
+++ b/tests/test_route.vala
@@ -26,6 +26,19 @@ public void test_route_from_rule () {
 /**
  * @since 0.1
  */
+public void test_route_from_rule_null () {
+	var route  = new Route.from_rule (new Router (), null, (req, res) => {});
+	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+
+	assert (route.match (request));
+	assert (request.params != null);
+	assert (request.params.contains ("path"));
+	assert ("5" == request.params["path"]);
+}
+
+/**
+ * @since 0.1
+ */
 public void test_route_from_rule_any () {
 	var route  = new Route.from_rule (new Router (), "<any:id>", (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -40,6 +40,7 @@ public int main (string[] args) {
 
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);
+	Test.add_func ("/route/from_rule/null", test_route_from_rule_null);
 	Test.add_func ("/route/from_rule/any", test_route_from_rule_any);
 	Test.add_func ("/route/from_rule/without_captures", test_route_from_rule_without_captures);
 


### PR DESCRIPTION
The rule used will automatically default to "<any:path>", according to the
definition of the any by the router. The matched path is made available in the
request parameters under the "path" key.

Since the router is principally rule-oriented, this feature allow a much better
integration of middlewares and setup operations.

Adds a test to ensure it works properly.

Documents the functionnality.