### PR TITLE
Removes cookies from VSGI.

### DIFF
--- a/docs/cookies.rst
+++ b/docs/cookies.rst
@@ -1,0 +1,40 @@
+Cookies
+=======
+
+HTTP cookies are stored in :doc:`vsgi/request` and :doc:`vsgi/response`
+headers.
+
+Various cookies utilities are provided in the ``Cookies`` namespace to
+compensate the fact that libsoup-2.4 utilities requires a `Soup.Message`_,
+which is not available in other VSGI implementations.
+
+They can be extracted as a singly-linked list from a request headers and an
+optional origin URI in their order of appearance (see `Soup.MessageHeaders.get_list`_ for more details).
+
+`SList.reverse`_ can be used to invert the order of cookies and respect the
+precedence.
+
+.. _Soup.Message: http://valadoc.org/#!api=libsoup-2.4/Soup.Message
+.. _Soup.MessageHeaders.get_list: http://valadoc.org/#!api=libsoup-2.4/Soup.MessageHeaders.get_list
+.. _SList.reverse: http://valadoc.org/#!api=glib-2.0/GLib.SList.reverse
+
+.. code:: vala
+
+    var cookies = Cookies.from_request_headers (req.headers, req.uri);
+
+    cookies.reverse ();
+
+    // obtain the last 'session' cookie
+    foreach (var cookie in cookies)
+        if (cookie.name == "session")
+            return cookie.value;
+
+libsoup-2.4 provides a complete implementation with `Soup.Cookie`_ that can be
+used to create a new cookie.
+
+.. _Soup.Cookie: http://valadoc.org/#!api=libsoup-2.4/Soup.Cookie
+
+.. code:: vala
+
+    var cookie = new Cookie ("name", "value", "0.0.0.0", "/", 60);
+    res.headers.append ("Set-Cookie", cookie.to_set_cookie_header ());

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Table Of Contents
     vsgi/request
     vsgi/response
     vsgi/server
+    cookies
     redirection-and-error
     route
     router

--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -75,26 +75,6 @@ from the ``headers`` property.
         var accept = req.headers.get_one ("Accept");
     });
 
-Cookies
--------
-
-Cookies can be accessed as a `GLib.SList`_ of `Soup.Cookie`_ from the `cookies`
-property or directly from the request headers.
-
-.. _GLib.SList: http://valadoc.org/#!api=glib-2.0/GLib.SList
-.. _Soup.Cookie: http://valadoc.org/#!api=libsoup-2.4/Soup.Cookie
-
-.. code:: vala
-
-    app.get ("", (req, res) => {
-        for (var cookie : req.cookies) {
-            res.write (cookie.get_name ().data);
-        }
-
-        // from the headers
-        var cookies = req.headers.get_list ("Cookie");
-    });
-
 Body
 ----
 

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -29,20 +29,6 @@ The response headers can be accessed as a `Soup.MessageHeaders`_ from the
         res.headers.set_content_type ("text/plain");
     })
 
-Cookies
--------
-
-Cookies can be written to the client using the ``cookies`` property. If you
-need to replace only a specific cookie, you should append it to the response
-headers.
-
-.. code:: vala
-
-    app.get ("", (req, res) => {
-        var new_cookies = new GLib.SList<Soup.Cookie> ();
-        res.cookies = new_cookies;
-    });
-
 Body
 ----
 

--- a/src/cookies.vala
+++ b/src/cookies.vala
@@ -1,0 +1,36 @@
+using GLib;
+using Soup;
+
+/**
+ * Various utilities for cookies.
+ *
+ * @since 0.1
+ */
+namespace Valum.Cookies {
+
+	/**
+	 * Extract cookies from the 'Cookie' request headers.
+	 *
+	 * @since 0.1
+
+	 * @param headers headers containing the cookies
+	 * @param uri     origin of the cookies
+	 */
+	public SList<Cookie> from_request_headers (MessageHeaders headers, URI? uri = null)
+			requires (headers.get_headers_type () == MessageHeadersType.REQUEST) {
+		var cookies     = new SList<Cookie> ();
+		var cookie_list = headers.get_list ("Cookie");
+
+		if (cookie_list == null)
+			return cookies;
+
+		foreach (var cookie in cookie_list.split ("; ")) {
+			if (cookie != null)
+				cookies.prepend (Cookie.parse (cookie, uri));
+		}
+
+		cookies.reverse ();
+
+		return cookies;
+	}
+}

--- a/src/router.vala
+++ b/src/router.vala
@@ -294,7 +294,6 @@ namespace Valum {
 			// sane initialization
 			res.status = Soup.Status.OK;
 			res.headers.set_content_type ("text/html", null);
-			res.cookies = req.cookies;
 
 			try {
 				try {

--- a/src/vsgi/request.vala
+++ b/src/vsgi/request.vala
@@ -98,31 +98,5 @@ namespace VSGI {
 		 * @since 0.0.1
 		 */
 		public abstract MessageHeaders headers { get; }
-
-		/**
-		 * Request cookies.
-         *
-		 * Cookies will be computed from the Cookie HTTP header everytime they are
-		 * accessed.
-		 *
-		 * @since 0.1
-		 */
-		public SList<Cookie> cookies {
-			owned get {
-				var cookies = new SList<Cookie> ();
-				var cookie_list = this.headers.get_list ("Cookie");
-
-				if (cookie_list == null)
-					return cookies;
-
-				foreach (var cookie in cookie_list.split ("; ")) {
-					cookies.prepend (Cookie.parse (cookie, this.uri));
-				}
-
-				cookies.reverse ();
-
-				return cookies;
-			}
-		}
 	}
 }

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -28,23 +28,5 @@ namespace VSGI {
 		 * @since 0.0.1
 		 */
 		public abstract MessageHeaders headers { get; }
-
-		/**
-		 * Response cookies.
-		 *
-		 * If set, the 'Set-Cookie' headers will be removed and replaced by
-		 * the new values.
-		 *
-		 * @since 0.1
-		 */
-		public SList<Cookie> cookies {
-			set {
-				this.headers.remove ("Set-Cookie");
-
-				foreach (var cookie in value) {
-					this.headers.append ("Set-Cookie", cookie.to_set_cookie_header ());
-				}
-			}
-		}
 	}
 }

--- a/tests/test_cookies.vala
+++ b/tests/test_cookies.vala
@@ -1,0 +1,17 @@
+using Soup;
+using Valum;
+
+/**
+ * @since 0.1
+ */
+public void test_cookies_from_request_headers () {
+	var headers = new MessageHeaders (MessageHeadersType.REQUEST);
+
+	headers.append ("Cookie", "a=b");
+
+	var cookies = Cookies.from_request_headers (headers);
+
+	assert (1 == cookies.length ());
+	assert ("a" == cookies.data.name);
+	assert ("b" == cookies.data.value);
+}

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -71,6 +71,8 @@ public int main (string[] args) {
 	Test.add_func ("/route/match/not_matching", test_route_match_not_matching);
 	Test.add_func ("/route/fire", test_route_match_not_matching);
 
+	Test.add_func ("/cookies/from_request_headers", test_cookies_from_request_headers);
+
 	Test.add_func ("/view/from_string", test_view_from_string);
 	Test.add_func ("/view/from_path", test_view_from_path);
 	Test.add_func ("/view/from_stream", test_view_from_stream);


### PR DESCRIPTION
Cookies are stored in HTTP headers, so it's not really relevant for VSGI
to provide helpers for them since it aims to be a minimal protocol.

Instead, the code to extract cookies is moved in 'cookies_from_headers'
function to provide equivalent parsing capabilities. The functions
provided by libsoup-2.4 for that purpose takes a Soup.Message as
parameter, which is not common to all VSGI implementations.