### PR TITLE
Provides invoke in the Router to execute an arbitrary NextCallback

### DIFF
--- a/docs/recipes/json.rst
+++ b/docs/recipes/json.rst
@@ -134,7 +134,8 @@ code duplication. They are described in the :doc:`../router` document.
     });
 
 It is also possible to use `Json.Parser.load_from_stream_async`_ and invoke
-`next` in the callback if you are expecting a considerable user input.
+`next` in the callback with :doc:`../router` ``invoke`` function if you are
+expecting a considerable user input.
 
 .. _Json.Parser.load_from_stream_async: http://www.valadoc.org/#!api=json-glib-1.0/Json.Parser.load_from_stream_async
 
@@ -142,7 +143,10 @@ It is also possible to use `Json.Parser.load_from_stream_async`_ and invoke
 
     parser.load_from_stream_async.begin (req.body, null, (obj, result) => {
         var success = parser.load_from_stream_async.end (result);
+
         user.update ();
-        next (user);
+
+        // execute 'next' in app context
+        app.invoke (req, res, next, user);
     });
 

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -673,3 +673,49 @@ public static void test_router_status_propagates_error_message () {
 
 	assert (418 == response.status);
 }
+
+/**
+ * @since 0.2
+ */
+public static void test_router_invoke () {
+	var router = new Router ();
+
+	router.get ("", (req, res, next) => {
+		router.invoke (req, res, next);
+	});
+
+	router.get ("", (req, res) => {
+		throw new ClientError.IM_A_TEAPOT ("this is insane!");
+	});
+
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}
+
+/**
+ * @since 0.2
+ */
+public static void test_router_invoke_propagate_state () {
+	var router  = new Router ();
+	var message = "test";
+
+	router.get ("", (req, res, next) => {
+		router.invoke (req, res, next, message);
+	});
+
+	router.get ("", (req, res, next, state) => {
+		assert (message == state.get_string ());
+		throw new ClientError.IM_A_TEAPOT ("this is insane!");
+	});
+
+	var request  = new Request (VSGI.Request.GET, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (418 == response.status);
+}

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -48,6 +48,9 @@ public int main (string[] args) {
 	Test.add_func ("/router/next/propagate_state", test_router_next_propagate_state);
 	Test.add_func ("/router/next/replace_propagated_state", test_router_next_replace_propagated_state);
 
+	Test.add_func ("/router/invoke", test_router_invoke);
+	Test.add_func ("/router/invoke/propagate_state", test_router_invoke_propagate_state);
+
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);
 	Test.add_func ("/route/from_rule/null", test_route_from_rule_null);


### PR DESCRIPTION
This solve the kind of situation where next has to be invoked in an async callback, but the exception handling is not available.

```vala

app.get ("", (req, res, next) => {
    res.write_async ("Hello world!".data, Priority.DEFAULT, null, (obj, result) => {
         // the 404 will be properly handled
        app.invoke (req, res, next);
    });
});

app.all (null, (req, res) => {
    throws ClientError.NOT_FOUND ("");
});

app.status (404, (req, res) => {
    // produce a 404 page...
});
```

It has the signature of a `HandlerCallback`, so I am pretty sure that it can be useful as a handling middleware.

I will write some tests and documentation and merge the changes.