### PR TITLE
Multipart streams

### DIFF
--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -162,6 +162,42 @@ app.get ("/tee", (req, res) => {
 	}
 });
 
+app.scope ("/multipart", () => {
+	app.use (accept ("text/html"));
+
+	app.get ("", (req, res) => {
+		return res.expand_utf8 ("""<!DOCTYPE html>
+		<html>
+		  <head>
+		    <title></title>
+		  </head>
+		  <body>
+		    <p>This demo shows how to handle <code>multipart/form-data</code> payloads.</p>
+		    <form method="post" enctype="multipart/form-data">
+		      <input name="filename" placeholder="Document Name">
+		      <input type="file" name="document">
+		      <input type="submit">
+		    </form>
+		  </body>
+		</html>""");
+	});
+
+	app.post ("", (req, res) => {
+		var mis = new MultipartInputStream.from_request (req);
+
+		var i = 1;
+		Soup.MessageHeaders? part_headers;
+		while (mis.next_part (out part_headers)) {
+			res.append_utf8 ("<h3>Part #%d</h3>".printf (i++));
+			res.append_utf8 ("<pre>");
+			res.body.splice (mis, OutputStreamSpliceFlags.NONE);
+			res.append_utf8 ("</pre>");
+		}
+
+		return res.end ();
+	});
+});
+
 // hello world! (compare with Node.js!)
 app.get ("/hello", respond_with_text (() => {
 	return "Hello world!";

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -182,9 +182,7 @@ app.scope ("/multipart", () => {
 		</html>""");
 	});
 
-	app.post ("", (req, res) => {
-		var mis = new MultipartInputStream.from_request (req);
-
+	app.post ("", multipart ((req, res, next, ctx, mis) => {
 		var i = 1;
 		Soup.MessageHeaders? part_headers;
 		while (mis.next_part (out part_headers)) {
@@ -193,9 +191,8 @@ app.scope ("/multipart", () => {
 			res.body.splice (mis, OutputStreamSpliceFlags.NONE);
 			res.append_utf8 ("</pre>");
 		}
-
 		return res.end ();
-	});
+	}));
 });
 
 // hello world! (compare with Node.js!)

--- a/examples/app/templates/home.html
+++ b/examples/app/templates/home.html
@@ -84,6 +84,7 @@
                 <li><a href="/cookies">cookies</a></li>
                 <li><a href="/urlencoded-data">urlencoded data</a></li>
                 <li><a href="/tee">tee</a></li>
+                <li><a href="/multipart">multipart</a></li>
               </ul>
               <h4>Router features</h4>
               <ul class="list-inline">

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,10 @@ if soup.version().version_compare('>=2.48')
     vala_defines += '--define=SOUP_2_48'
 endif
 
+if meson.get_compiler('c').has_function('memmem')
+    vala_defines += '--define=HAVE_MEMMEM'
+endif
+
 subdir('src')
 subdir('bin')
 subdir('tests')

--- a/src/valum/meson.build
+++ b/src/valum/meson.build
@@ -12,6 +12,7 @@ valum_sources = files(
     'valum-matcher-route.vala',
     'valum-method.vala',
     'valum-content-negotiation.vala',
+    'valum-multipart.vala',
     'valum-path-route.vala',
     'valum-regex-route.vala',
     'valum-respond-with.vala',

--- a/src/valum/valum-multipart.vala
+++ b/src/valum/valum-multipart.vala
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+using VSGI;
+
+namespace Valum {
+
+	/**
+	 * Forward a {@link VSGI.MultipartInputStream} if the incoming request is multipart.
+	 *
+	 * If the 'boundary' parameter is missing, a {@link ClientError.BAD_REQUEST}
+	 * is raised.
+	 *
+	 * For regular requests, 'next' is called.
+	 */
+	[Version (since = "0.4")]
+	public HandlerCallback multipart (ForwardCallback<MultipartInputStream> forward) {
+		return (req, res, next, ctx) => {
+			HashTable<string, string> @params;
+			if (req.headers.get_content_type (out @params).has_prefix ("multipart/")) {
+				if (!@params.contains ("boundary")) {
+					throw new ClientError.BAD_REQUEST ("The 'boundary' parameter is missing in the 'Content-Type' header.");
+				}
+				return forward (req, res, next, ctx, new MultipartInputStream (req.body, @params["boundary"]));
+			} else {
+				return next ();
+			}
+		};
+	}
+}

--- a/src/vsgi/meson.build
+++ b/src/vsgi/meson.build
@@ -9,6 +9,8 @@ vsgi_sources = files(
     'vsgi-cookie-utils.vala',
     'vsgi-handler-module.vala',
     'vsgi-handler.vala',
+    'vsgi-multipart-input-stream.vala',
+    'vsgi-multipart-output-stream.vala',
     'vsgi-request.vala',
     'vsgi-response.vala',
     'vsgi-security-utils.vala',

--- a/src/vsgi/vsgi-multipart-input-stream.vala
+++ b/src/vsgi/vsgi-multipart-input-stream.vala
@@ -1,0 +1,152 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+
+/**
+ * Equivalent to {@link Posix.strstr} but for memory blocks.
+ */
+private extern unowned void* memmem (void* haystack, size_t haystack_len, void* needle, size_t needle_len);
+
+/**
+ * Multipart input stream conforming to RFC 1341.
+ */
+public class VSGI.MultipartInputStream : FilterInputStream {
+
+	private DataInputStream data_base_stream;
+
+	[Version (since = "0.4")]
+	public string boundary { construct; get; }
+
+	[Version (since = "0.4")]
+	public MultipartInputStream (InputStream base_stream, string boundary) {
+		Object (base_stream: base_stream, boundary: boundary);
+	}
+
+	[Version (since = "0.4")]
+	public MultipartInputStream.from_request (Request req) {
+		HashTable<string, string> @params;
+		req.headers.get_content_type (out @params);
+		this (req.body, @params["boundary"]);
+	}
+
+	construct {
+		data_base_stream = new DataInputStream (base_stream);
+		data_base_stream.set_newline_type (DataStreamNewlineType.CR_LF);
+	}
+
+	/**
+	 * Position the stream on the next part of the message, skipping content
+	 * from the current part if necessary.
+	 *
+	 * This will initially skip the preamble, so it's also possible to read
+	 * from the stream before calling 'next_part'.
+	 *
+	 * If no part are available, 'false' is returned and the stream will be
+	 * positioned on the epilogue.
+	 *
+	 * @param part_headers headers of the part
+	 * @return 'true' if the stream is positionned on the next part, 'false'
+	 *         otherwise
+	 */
+	[Version (since = "0.4")]
+	public bool next_part (out Soup.MessageHeaders part_headers, Cancellable? cancellable = null) throws IOError {
+		part_headers = new Soup.MessageHeaders (Soup.MessageHeadersType.MULTIPART);
+
+		// skip until the next part
+		string? line = null;
+		do {
+			line = data_base_stream.read_line (null, cancellable);
+
+			// end of input (premature?)
+			if (line == null) {
+				return false;
+			}
+
+			// closing frontier (epilogue follows)
+			if (line == "--%s--".printf (boundary)) {
+				return false;
+			}
+		} while (line != "--%s".printf (boundary));
+
+		// consume the part headers
+		var headers = new StringBuilder ();
+
+		do {
+			line = data_base_stream.read_line (null, cancellable);
+
+			if (line == null) {
+				return false; // early end of input..?
+			}
+
+			headers.append_printf ("%s\r\n", line);
+		} while (line != "");
+
+		return Soup.headers_parse (headers.str, (int) headers.len, part_headers);
+	}
+
+	/**
+	 * Obtain the next part asynchronously.
+	 */
+	[Version (since = "0.4")]
+	public async bool next_part_async (int                     priority    = GLib.Priority.DEFAULT,
+	                                   Cancellable?            cancellable = null,
+	                                   out Soup.MessageHeaders part_headers) throws Error {
+		return next_part (out part_headers, cancellable);
+	}
+
+	/*
+	private ssize_t m = -1;
+	*/
+
+	/**
+	 * Read and skip boundaries, raising a 'EOF' before each occurences.
+	 */
+	public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
+		var needle = "\r\n--%s\r\n".printf (boundary);
+		var epilogue_needle = "\r\n--%s--\r\n".printf (boundary);
+
+		// peek the base stream such that it contains at least any of the needles
+		var peek_buffer = new uint8[buffer.length + uint.max (needle.length, epilogue_needle.length)];
+		try {
+			data_base_stream.fill (peek_buffer.length);
+		} catch (Error err) {
+			critical ("%s (%s, %d)", err.message, err.domain.to_string (), err.code);
+		}
+		var bytes_read = data_base_stream.peek (peek_buffer);
+
+		// check if the boundary is anywhere in the buffer
+		var needle_in_buffer = memmem (peek_buffer, bytes_read, needle, needle.length);
+
+		if (needle_in_buffer != null) {
+			return data_base_stream.read (buffer[0:((uint8*) needle_in_buffer - (uint8*) peek_buffer)], cancellable);
+		}
+
+		// check for epilogue boundary
+		var epilogue_needle_in_buffer = memmem (peek_buffer, bytes_read, epilogue_needle, needle.length);
+
+		if (epilogue_needle_in_buffer != null) {
+			return data_base_stream.read (buffer[0:((uint8*) epilogue_needle_in_buffer - (uint8*) peek_buffer)], cancellable);
+		}
+
+		return data_base_stream.read (buffer, cancellable);
+	}
+
+	public override bool close (Cancellable? cancellable = null) throws IOError {
+		return base_stream.close (cancellable);
+	}
+}

--- a/src/vsgi/vsgi-multipart-output-stream.vala
+++ b/src/vsgi/vsgi-multipart-output-stream.vala
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+
+/**
+ * Stream designed to produce multipart MIME messages.
+ *
+ * To create a part, {@link VSGI.MultipartOutputStream.new_part} has to be
+ * called. The actual part body must be written directly in the stream.
+ */
+[Version (since = "0.4")]
+public class VSGI.MultipartOutputStream : FilterOutputStream {
+
+	/**
+	 * Boundary to separate the different parts of the message.
+	 */
+	[Version (since = "0.4")]
+	public string boundary { construct; get; }
+
+	/**
+	 * Epilogue to be written when closing the stream.
+	 */
+	[Version (since = "0.4")]
+	public string? epilogue { get; set; default = null; }
+
+	[Version (since = "0.4")]
+	public MultipartOutputStream (OutputStream base_stream, string boundary) {
+		Object (base_stream: base_stream, boundary: boundary);
+	}
+
+	[Version (since = "0.4")]
+	public MultipartOutputStream.from_response (Response res) {
+		HashTable<string, string> @params;
+		res.headers.get_content_type (out @params);
+		this (res.body, @params["boundary"]);
+	}
+
+	private uint8[] build_part (Soup.MessageHeaders part_headers) {
+		var part = new StringBuilder ("");
+
+		part.append_printf ("\r\n--%s\r\n", boundary);
+
+		part_headers.foreach ((k, v) => {
+			part.append_printf ("%s: %s\r\n", k, v);
+		});
+
+		part.append ("\r\n");
+
+		return part.str.data;
+	}
+
+	/**
+	 * Create a new part in this multipart message.
+	 *
+	 * The opening boundary and headers are written in the base stream,
+	 * preparing the land for the body to be written.
+	 */
+	[Version (since = "0.4")]
+	public bool new_part (Soup.MessageHeaders? part_headers = null) throws IOError {
+		return base_stream.write_all (build_part (part_headers ?? new Soup.MessageHeaders (Soup.MessageHeadersType.MULTIPART)), null);
+	}
+
+	/**
+	 * @see VSGI.MultipartOutputStream.new_part
+	 */
+	[Version (since = "0.4")]
+	public async bool new_part_async (Soup.MessageHeaders part_headers,
+	                                  int                 priority    = GLib.Priority.DEFAULT,
+	                                  Cancellable?        cancellable = null) throws Error {
+#if GIO_2_44
+		size_t bytes_written;
+		return yield base_stream.write_all_async (build_part (part_headers ?? new Soup.MessageHeaders
+															  (Soup.MessageHeadersType.MULTIPART)), priority, cancellable, out bytes_written);
+#else
+		return new_part (part_headers);
+#endif
+	}
+
+	public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
+		return base_stream.write (buffer, cancellable);
+	}
+
+	/**
+	 * Append the final enclosing boundary and close the base stream.
+	 */
+	public override bool close (Cancellable? cancellable = null) throws IOError {
+		return base_stream.write_all ("\r\n--%s--\r\n".printf (boundary).data, null, cancellable) &&
+		       base_stream.write_all (epilogue.data, null, cancellable) &&
+		       base_stream.close (cancellable);
+	}
+}

--- a/tests/data/multipart/simple-message
+++ b/tests/data/multipart/simple-message
@@ -1,0 +1,15 @@
+This is the preamble.  It is to be ignored, though it
+is a handy place for mail composers to include an
+explanatory note to non-MIME compliant readers.
+--simple boundary
+
+This is implicitly typed plain ASCII text.
+It does NOT end with a linebreak.
+--simple boundary
+Content-type: text/plain; charset=us-ascii
+
+This is explicitly typed plain ASCII text.
+It DOES end with a linebreak.
+
+--simple boundary--
+This is the epilogue.  It is also to be ignored.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,9 @@ test('legacy', executable('legacy-test', legacy_test_sources,
 # VSGI tests
 test('auth', executable('auth-test', 'auth-test.vala',
                         dependencies: [glib, gobject, gio, soup, vsgi]))
+test('multipart', executable('multipart-test', 'multipart-test.vala',
+                             dependencies: [glib, gobject, gio, soup, vsgi]),
+     env: ['G_TEST_SRCDIR=' + meson.current_source_dir()])
 test('request', executable('request-test', 'request-test.vala',
                            dependencies: [glib, gobject, gio, soup, vsgi]))
 test('response', executable('response-test', 'response-test.vala',

--- a/tests/multipart-test.vala
+++ b/tests/multipart-test.vala
@@ -1,0 +1,92 @@
+
+using GLib;
+using VSGI;
+
+public int main (string[] args) {
+	Test.init (ref args);
+
+	Test.add_func ("/multipart_input_stream", () => {
+		MultipartInputStream @in;
+
+		try {
+			@in = new MultipartInputStream (File.new_for_path (Test.get_filename (Test.FileType.DIST, "data", "multipart", "simple-message")).read (),
+			                                "simple boundary");
+
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+
+		Soup.MessageHeaders part_headers;
+
+		var preamble    = new MemoryOutputStream.resizable ();
+		var first_part  = new MemoryOutputStream.resizable ();
+		var second_part = new MemoryOutputStream.resizable ();
+		var epilogue    = new MemoryOutputStream.resizable ();
+
+		try {
+			preamble.splice (@in, OutputStreamSpliceFlags.NONE);
+			assert (153 == preamble.get_data_size ());
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+
+		try {
+			assert (@in.next_part (out part_headers));
+			first_part.splice (@in, OutputStreamSpliceFlags.NONE);
+			assert (77 == first_part.get_data_size ());
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+
+		try {
+			assert (@in.next_part (out part_headers));
+			second_part.splice (@in, OutputStreamSpliceFlags.NONE);
+			assert (75 == second_part.get_data_size ());
+			assert ('\r' == second_part.get_data ()[73]);
+			assert ('\n' == second_part.get_data ()[74]);
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+
+		try {
+			assert (!@in.next_part (out part_headers));
+			epilogue.splice (@in, OutputStreamSpliceFlags.NONE);
+			assert (50 == epilogue.get_data_size ());
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+	});
+
+	Test.add_func ("/multipart_output_stream", () => {
+		var mos = new MemoryOutputStream.resizable ();
+		var @out = new MultipartOutputStream (mos, "simple boundary");
+
+		try {
+			@out.new_part ();
+			@out.write_all ("Hello world!".data, null);
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+
+		@out.epilogue = "foo bar";
+
+		@out.close ();
+
+		var @in = new MultipartInputStream (new MemoryInputStream.from_bytes (mos.steal_as_bytes ()), "simple boundary");
+
+		Soup.MessageHeaders part_headers;
+		assert (@in.next_part (out part_headers));
+		uint8 buffer[1024];
+		size_t bytes_read;
+		@in.read_all (buffer, out bytes_read);
+		assert (12 == bytes_read);
+		assert (Memory.cmp ("Hello world!".data, buffer, 12) == 0);
+
+		assert (!@in.next_part (out part_headers));
+		@in.read_all (buffer, out bytes_read);
+		assert (7 == bytes_read);
+		assert (Memory.cmp ("foo bar".data, buffer, 7) == 0);
+	});
+
+	return Test.run ();
+}


### PR DESCRIPTION
The multipart streams provided by libsoup-2.4 require a `Soup.Message` instance which is not common to all VSGI implementations.

This PR provides implementation for `MultipartInputStream` and `MultipartOutputStream` that are similar to what libsoup-2.4 already provides, but adapted to what VSGI is based on.

Implementation reference: http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
