### PR TITLE
Apply multiple Transfer-Encoding.

### DIFF
--- a/docs/route.rst
+++ b/docs/route.rst
@@ -25,10 +25,12 @@ Request parameters
 .. deprecated:: 0.2
     Request parameters are stored in the stack.
 
-It is important to keep in mind that the request parameters result from
-a side-effect. If a matcher accept the request, it may populate the parameters.
-The matching process in :doc:`router` guarantees that only one matcher can
-accept the request and thus populate the parameters.
+.. warning::
+
+    It is important to keep in mind that the request parameters result from
+    a side-effect. If a matcher accept the request, it may populate the
+    parameters. The matching process in :doc:`router` guarantees that only one
+    matcher can accept the request and thus populate the parameters.
 
 Request can be parametrized in a general manner:
 
@@ -240,9 +242,9 @@ accept the request.
 Handler
 -------
 
-Handler process a a pair of :doc:`vsgi/request` and :doc:`vsgi/response` and
-can throw various status code during the processing to handle cases that breaks
-the code flow conveniently.
+Handler process a pair of :doc:`vsgi/request` and :doc:`vsgi/response` and can
+throw various status code during the processing to handle cases that breaks the
+code flow conveniently. They are fully covered in the :doc:`router` document.
 
 See :doc:`redirection-and-error` for more details on what can be throws during
 the processing of a handler.

--- a/docs/vsgi/index.rst
+++ b/docs/vsgi/index.rst
@@ -37,15 +37,16 @@ a :doc:`request` and a :doc:`response`.
         // process the request and produce the response...
     }).run ();
 
-The callback must at least access the :doc:`response` body once so that the
-headers can be written and filters be applied, otherwise nothing will be sent
-to the client and the connection will be closed.
-
 Accessing the :doc:`response` ``body`` for the first time will write the status
 line and headers synchronously in the connection stream before returning an
 `GLib.OutputStream`_.
 
 .. _GLib.OutputStream: http://valadoc.org/#!api=gio-2.0/GLib.OutputStream
+
+.. warning::
+
+    The :doc:`response` body must be accessed at least once during the
+    processing to ensure that the headers will be written and filters applied.
 
 Asynchronous processing
 -----------------------
@@ -63,10 +64,14 @@ The :doc:`request` holds a reference to the said connection and the
 Generally speaking, holding a reference on any of these two instances is
 sufficient to keep the streams usable.
 
-Synchronously, that does not make a difference because the request and response
-bodies will be freed properly before the connection, avoiding any kind of
-message corruption. However, asynchronously, the connection must persist until
-all streams operations are done as demonstrated in the following example:
+.. warning::
+
+    As VSGI relies on reference counting to free the resources underlying
+    a request, you must keep a reference to either the :doc:`request` or
+    :doc:`response` during the processing, including in asynchronous callbacks.
+
+It is important that the connection persist until all streams operations are
+done as the following example demonstrates:
 
 .. code:: vala
 

--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -34,6 +34,10 @@ plain strings to describe standard HTTP methods.
 Request parameters
 ------------------
 
+.. deprecated:: 0.2
+
+    Use the routing stack described in the :doc:`../router` documentation.
+
 The request parameters are stored in a `GLib.HashTable`_ of ``string`` to
 ``string`` and can be accessed from the ``Request.params`` property. It's used
 as a general metadata storage for requests.

--- a/docs/vsgi/server/scgi.rst
+++ b/docs/vsgi/server/scgi.rst
@@ -4,8 +4,10 @@ SCGI
 SCGI (Simple Common Gateway Interface) is a stream-based protocol that is
 particularly simple to implement.
 
-The implementation takes the best out of GIO asynchronous APIs as it is purely
-implemented with it.
+.. note::
+
+    SCGI is the recommended implementation and should be used when available as
+    it takes the best out of GIO asynchronous API.
 
 .. _GLib.SocketService:
 
@@ -13,14 +15,21 @@ implemented with it.
 
     using VSGI.SCGI;
 
+    var shared_state = 5;
+
     app.get ("", (req, res) => {
         // ...
+        lock (shared_state) {
+            shared_state++;
+        }
     });
 
     new Server (app.handle).run ();
 
-Connections being handling in worker threads, it is critical to avoid shared
-state or to use `GLib.Mutex`_ properly.
+.. warning::
+
+    Connections being handling in worker threads, it is critical to avoid
+    shared state or to use `GLib.Mutex`_ or ``lock`` properly.
 
 .. _GLib.Mutex: http://valadoc.org/#!api=glib-2.0/GLib.Mutex
 

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -43,6 +43,11 @@ app.get ("gzip", (req, res) => {
 	template.to_stream (writer);
 });
 
+app.get ("lulz", (req, res) => {
+		res.headers.replace ("Transfer-Encoding", "gzip, chunked");
+		res.body.write ("Hello world!".data);
+});
+
 app.get ("query", (req, res) => {
 	var writer = new DataOutputStream (res.body);
 

--- a/src/router.vala
+++ b/src/router.vala
@@ -236,7 +236,7 @@ namespace Valum {
 		 * @param routes sequence of routes to traverse
 		 * @param req    request
 		 * @param res    response
-		 * @param state  propagated state
+		 * @param stack  routing stack passed to match and fire
 		 * @return tells if something matched during the routing process
 		 */
 		private bool perform_routing (List<Route> routes, Request req, Response res, Queue<Value?> stack) throws Informational, Success, Redirection, ClientError, ServerError {

--- a/src/valum.vala
+++ b/src/valum.vala
@@ -26,7 +26,7 @@ namespace Valum {
 	 * @since 0.1
 	 *
 	 * @param req           request being matched
-	 * @param initial_stack stacked request parameters
+	 * @param initial_stack destination for the initial routing stack
 	 */
 	public delegate bool MatcherCallback (Request req, Queue<Value?> initial_stack);
 
@@ -42,18 +42,23 @@ namespace Valum {
 	 * @param req   request being handled
 	 * @param res   response to send back to the requester
 	 * @param next  keep routing
-	 * @param state propagated state from a preceeding next invocation, it
-	 *              remains null if this is the top invocation or no state
-	 *              have been propagated
+	 * @param stack routing stack as altered by the preceeding next invocation
+	 *              or initialized by the first {@link Valum.MatcherCallback}
 	 */
 	public delegate void HandlerCallback (Request req, Response res, NextCallback next, Queue<Value?> stack) throws Informational, Success, Redirection, ClientError, ServerError;
 
 	/**
-	 * Keeps routing the {@link VSGI.Request} and {@link VSGI.Response}.
+	 * Continuation passed in a {@link Valum.HandlerCallback} to *keep routing*
+	 * both {@link VSGI.Request} and {@link VSGI.Response}.
+	 *
+	 * It is also used as a generic continuation that propagates a thrown status
+	 * code.
 	 *
 	 * @since 0.1
 	 *
-	 * @param state propagated state to the next handler
+	 * @throws Redirection perform a 3xx HTTP redirection
+	 * @throws ClientError trigger a 4xx client error
+	 * @throws ServerError trigger a 5xx server error
 	 */
 	public delegate void NextCallback () throws Informational, Success, Redirection, ClientError, ServerError;
 }


### PR DESCRIPTION
The current implementation does not apply `Transfer-Encoding` iteratively, so we cannot send compressed and chunked messages.