### PR TITLE
Default implementation for HEAD.

### DIFF
--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -21,11 +21,6 @@ app.methods ({VSGI.Request.GET, VSGI.Request.POST}, "get-and-post", (req, res) =
 	res.body.write ("Matches GET and POST".data);
 });
 
-app.all (null, (req, res, next) => {
-	res.headers.append ("Server", "Valum/1.0");
-	next ();
-});
-
 app.all ("all", (req, res) => {
 	res.body.write ("Matches all HTTP methods".data);
 });

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -452,7 +452,7 @@ public static void test_router_method_not_allowed () {
 	router.handle (request, response);
 
 	assert (response.status == 405);
-	assert ("PUT, GET" == response.headers.get_one ("Allow"));
+	assert ("PUT, GET, HEAD" == response.headers.get_one ("Allow"));
 	assert (response.head_written);
 }
 
@@ -484,8 +484,27 @@ public static void test_router_method_not_allowed_excludes_request_method () {
 	assert (get_matched == 1);
 
 	assert (response.status == 405);
-	assert ("GET" == response.headers.get_one ("Allow"));
+	assert ("GET, HEAD" == response.headers.get_one ("Allow"));
 	assert (response.head_written);
+}
+
+/**
+ * @since 0.2
+ */
+public void test_router_method_not_allowed_head_if_get () {
+	var router = new Router ();
+
+	router.get ("", (req, res) => {
+		res.body.write ("Hello world!".data);
+	});
+
+	var request  = new Request (VSGI.Request.PUT, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (405 == response.status);
+	assert ("GET, HEAD" == response.headers.get_one ("Allow"));
 }
 
 /**
@@ -718,4 +737,22 @@ public static void test_router_invoke_propagate_state () {
 	router.handle (request, response);
 
 	assert (418 == response.status);
+}
+
+/**
+ * @since 0.2
+ */
+public void test_router_default_head () {
+	var router = new Router ();
+
+	router.get ("", (req, res) => {
+		res.body.write ("Hello world!".data);
+	});
+
+	var request  = new Request (VSGI.Request.HEAD, new Soup.URI ("http://localhost/"));
+	var response = new Response (request, Soup.Status.OK);
+
+	router.handle (request, response);
+
+	assert (200 == response.status);
 }

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -51,6 +51,9 @@ public int main (string[] args) {
 	Test.add_func ("/router/invoke", test_router_invoke);
 	Test.add_func ("/router/invoke/propagate_state", test_router_invoke_propagate_state);
 
+	Test.add_func ("/router/default_head", test_router_default_head);
+	Test.add_func ("/router/method_not_allowed/head_if_get", test_router_method_not_allowed_head_if_get);
+
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);
 	Test.add_func ("/route/from_rule/null", test_route_from_rule_null);


### PR DESCRIPTION
Provides a default implementation for the HEAD method by passing the
request to the GET handlers.

 - request preserves the HEAD method, so GET implementation can use it
   to prevent the body from being written in the stream

If GET matches, HEAD is added to the 'Allowed' header as the default
implementation covers it.

Removes the catch-all example as it prevents the default HEAD
implementation from being triggered.