### PR TITLE
[WIP] Reuses a matcher with then in Route.

### DIFF
--- a/docs/router.rst
+++ b/docs/router.rst
@@ -233,6 +233,25 @@ data to the next handler in the queue.
 The ``Router`` will automatically propagate the state, so calling ``next``
 without argument is a safe operation.
 
+Sequence
+--------
+
+:doc:`route` has a ``then`` function that can be used to produce to sequence
+handlers for a common matcher. It can be used to create a pipeline of
+processing for a resource using handling middlewares.
+
+.. code:: vala
+
+    app.get ("admin", (req, res, next) => {
+        // authenticate user...
+        next ();
+    }).then ((req, res, next) => {
+        // produce sensitive data...
+        next ();
+    }).then ((req, res) => {
+        // produce the response
+    });
+
 Invoke
 ------
 

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -11,9 +11,12 @@ mcd.add_server ("127.0.0.1", 11211);
 app.types["permutations"] = /abc|acb|bac|bca|cab|cba/;
 
 // default route
-app.get ("", (req, res) => {
+app.get ("", (req, res, next) => {
+	// reuse the same matcher...
+	res.headers.set_content_type ("text/html", null);
+	next ();
+}).then ((req, res) => {
 	var template = new View.from_stream (resources_open_stream ("/templates/home.html", ResourceLookupFlags.NONE));
-
 	template.to_stream (res.body);
 });
 

--- a/src/route.vala
+++ b/src/route.vala
@@ -26,6 +26,11 @@ namespace Valum {
 		public weak Router router { construct; get; }
 
 		/**
+		 * @since 0.3
+		 */
+		public string? method { construct; get; }
+
+		/**
 		 * Create a Route using a custom matcher.
 		 *
 		 * This is the lowest-level mean to create a Route instance.
@@ -35,8 +40,8 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public Route (Router router, MatcherCallback matcher, HandlerCallback callback) {
-			Object (router: router);
+		public Route (Router router, string? method, MatcherCallback matcher, HandlerCallback callback) {
+			Object (router: router, method: method);
 			this.match  = matcher;
 			this.fire   = callback;
 		}
@@ -54,8 +59,8 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public Route.from_regex (Router router, Regex regex, HandlerCallback callback) throws RegexError {
-			Object (router: router);
+		public Route.from_regex (Router router, string? method, Regex regex, HandlerCallback callback) throws RegexError {
+			Object (router: router, method: method);
 			this.fire = callback;
 
 			var pattern = new StringBuilder ("^");
@@ -117,8 +122,8 @@ namespace Valum {
 		 * @param rule compiled down ot a regular expression and captures all
 		 *             paths if set to null
 		 */
-		public Route.from_rule (Router router, string? rule, HandlerCallback callback) throws RegexError {
-			Object (router: router);
+		public Route.from_rule (Router router, string? method, string? rule, HandlerCallback callback) throws RegexError {
+			Object (router: router, method: method);
 			this.fire = callback;
 
 			var param_regex = new Regex ("(<(?:\\w+:)?\\w+>)");
@@ -194,5 +199,13 @@ namespace Valum {
 		 * @since 0.0.1
 		 */
 		public HandlerCallback fire;
+
+		/**
+		 * Pushes the handler in the {@link Router} queue to produce a sequence
+		 * of callbacks that reuses the same matcher.
+		 */
+		public Route then (HandlerCallback handler) {
+			return this.router.matcher (this.method, match, handler);
+		}
 	}
 }

--- a/src/router.vala
+++ b/src/router.vala
@@ -48,57 +48,57 @@ namespace Valum {
 		/**
 		 * @since 0.0.1
 		 */
-		public new void get (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.GET, rule, cb);
+		public new Route get (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.GET, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void post (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.POST, rule, cb);
+		public Route post (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.POST, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void put (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.PUT, rule, cb);
+		public Route put (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.PUT, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void delete (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.DELETE, rule, cb);
+		public Route delete (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.DELETE, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void head (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.HEAD, rule, cb);
+		public Route head (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.HEAD, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void options(string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.OPTIONS, rule, cb);
+		public Route options (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.OPTIONS, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public void trace (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.TRACE, rule, cb);
+		public Route trace (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.TRACE, rule, cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public new void connect (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.CONNECT, rule, cb);
+		public new Route connect (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.CONNECT, rule, cb);
 		}
 
 		/**
@@ -106,8 +106,8 @@ namespace Valum {
 		 *
 		 * @since 0.0.1
 		 */
-		public void patch (string? rule, HandlerCallback cb) throws RegexError {
-			this.method (Request.PATCH, rule, cb);
+		public Route patch (string? rule, HandlerCallback cb) throws RegexError {
+			return this.method (Request.PATCH, rule, cb);
 		}
 
 		/**
@@ -122,8 +122,8 @@ namespace Valum {
 		 * @param rule   rule
 		 * @param cb     callback used to process the pair of request and response.
 		 */
-		public void method (string method, string? rule, HandlerCallback cb) throws RegexError {
-			this.route (method, new Route.from_rule (this, rule, cb));
+		public Route method (string method, string? rule, HandlerCallback cb) throws RegexError {
+			return this.route (method, new Route.from_rule (this, method, rule, cb));
 		}
 
 		/**
@@ -144,7 +144,7 @@ namespace Valum {
 		 * @param rule    rule
 		 */
 		public void methods (string[] methods, string? rule, HandlerCallback cb) throws RegexError {
-			var route = new Route.from_rule (this, rule, cb);
+			var route = new Route.from_rule (this, null, rule, cb);
 			foreach (var method in methods) {
 				this.route (method, route);
 			}
@@ -162,8 +162,8 @@ namespace Valum {
 		 * @param regex  regular expression matching the request path.
 		 * @param cb     callback used to process the pair of request and response.
 		 */
-		public void regex (string method, Regex regex, HandlerCallback cb) throws RegexError {
-			this.route (method, new Route.from_regex (this, regex, cb));
+		public Route regex (string method, Regex regex, HandlerCallback cb) throws RegexError {
+			return this.route (method, new Route.from_regex (this, method, regex, cb));
 		}
 
 		/**
@@ -175,8 +175,8 @@ namespace Valum {
 		 * @param matcher callback used to match the request
 		 * @param cb      callback used to process the pair of request and response.
 		 */
-		public void matcher (string method, MatcherCallback matcher, HandlerCallback cb) {
-			this.route (method, new Route (this, matcher, cb));
+		public Route matcher (string method, MatcherCallback matcher, HandlerCallback cb) {
+			return this.route (method, new Route (this, method, matcher, cb));
 		}
 
 		/**
@@ -188,11 +188,13 @@ namespace Valum {
 		 * @param route  an instance of Route defining the matching process and the
 		 *               callback.
 		 */
-		private void route (string method, Route route) {
+		private Route route (string method, Route route) {
 			if (!this.routes.contains (method))
 				this.routes[method] = new Queue<Route> ();
 
 			this.routes[method].push_tail (route);
+
+			return route;
 		}
 
 		/**
@@ -208,7 +210,7 @@ namespace Valum {
 			if (!this.status_handlers.contains (status))
 				this.status_handlers[status] = new Queue<Route> ();
 
-			this.status_handlers[status].push_tail (new Route (this, () => { return true; }, cb));
+			this.status_handlers[status].push_tail (new Route (this, null, () => { return true; }, cb));
 		}
 
 		/**

--- a/tests/test_route.vala
+++ b/tests/test_route.vala
@@ -6,7 +6,7 @@ using VSGI.Test;
  */
 public void test_route () {
 	var router = new Router ();
-	var route  = new Route (router, (req) => { return true; }, (req, res) => {});
+	var route  = new Route (router, "GET", (req) => { return true; }, (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (req));
@@ -17,7 +17,7 @@ public void test_route () {
  * @since 0.1
  */
 public void test_route_from_rule () {
-	var route  = new Route.from_rule (new Router (), "<int:id>", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (request));
@@ -29,7 +29,7 @@ public void test_route_from_rule () {
  * @since 0.1
  */
 public void test_route_from_rule_null () {
-	var route  = new Route.from_rule (new Router (), null, (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (request));
@@ -42,7 +42,7 @@ public void test_route_from_rule_null () {
  * @since 0.1
  */
 public static void test_route_from_rule_null_matches_empty_path () {
-	var route  = new Route.from_rule (new Router (), null, (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
 
 	assert (route.match (request));
@@ -52,7 +52,7 @@ public static void test_route_from_rule_null_matches_empty_path () {
  * @since 0.1
  */
 public void test_route_from_rule_any () {
-	var route  = new Route.from_rule (new Router (), "<any:id>", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "<any:id>", (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (request));
@@ -64,7 +64,7 @@ public void test_route_from_rule_any () {
  * @since 0.1
  */
 public void test_route_from_rule_without_captures () {
-	var route  = new Route.from_rule (new Router (), "", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "", (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/"));
 
 	assert (req.params == null);
@@ -80,14 +80,14 @@ public void test_route_from_rule_without_captures () {
  * @since 0.1
  */
 public void test_route_from_rule_undefined_type () {
-	var route  = new Route.from_rule (new Router (), "<uint:unknown_type>", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "<uint:unknown_type>", (req, res) => {});
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_regex () {
-	var route  = new Route.from_regex (new Router (), /(?<id>\d+)/, (req, res) => {});
+	var route  = new Route.from_regex (new Router (), "GET", /(?<id>\d+)/, (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (req.params == null);
@@ -107,7 +107,7 @@ public void test_route_from_regex_scoped () {
 
 	router.scopes.push_tail ("test");
 
-	var route  = new Route.from_regex (router, /(?<id>\d+)/, (req, res) => {});
+	var route  = new Route.from_regex (router, "GET", /(?<id>\d+)/, (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/test/5"));
 
 	assert (req.params == null);
@@ -123,7 +123,7 @@ public void test_route_from_regex_scoped () {
  * @since 0.1
  */
 public void test_route_from_regex_without_captures () {
-	var route  = new Route.from_regex (new Router (), /.*/, (req, res) => {});
+	var route  = new Route.from_regex (new Router (), "GET", /.*/, (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/"));
 
 	var matches = route.match (req);
@@ -137,7 +137,7 @@ public void test_route_from_regex_without_captures () {
  * @since 0.1
  */
 public void test_route_match () {
-	var route  = new Route.from_rule (new Router (), "<int:id>", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (req.params == null);
@@ -153,7 +153,7 @@ public void test_route_match () {
  * @since 0.1
  */
 public void test_route_match_not_matching () {
-	var route  = new Route.from_rule (new Router (), "<int:id>", (req, res) => {});
+	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
 	var req    = new Request.with_uri (new Soup.URI ("http://localhost/home"));
 
 	// no match and params remains null
@@ -166,7 +166,7 @@ public void test_route_match_not_matching () {
  */
 public void test_route_fire () {
 	var setted = false;
-	var route = new Route.from_rule (new Router (), "<int:id>", (req, res) => {
+	var route = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {
 		setted = true;
 	});
 	var req   = new Request.with_uri (new Soup.URI ("http://localhost/home"));

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -719,3 +719,29 @@ public static void test_router_invoke_propagate_state () {
 
 	assert (418 == response.status);
 }
+
+/**
+ * @since 0.2
+ */
+public void test_router_then () {
+	var router = new Router ();
+
+	var setted      = false;
+	var then_setted = false;
+
+	router.get ("<int:id>", (req, res, next) => {
+		setted = true;
+		next ();
+	}).then ((req, res) => {
+		assert (setted);
+		then_setted = true;
+	});
+
+	var req = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+	var res = new Response (req, 200);
+
+	router.handle (req, res);
+
+	assert (setted);
+	assert (then_setted);
+}

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -51,6 +51,8 @@ public int main (string[] args) {
 	Test.add_func ("/router/invoke", test_router_invoke);
 	Test.add_func ("/router/invoke/propagate_state", test_router_invoke_propagate_state);
 
+	Test.add_func ("/router/then", test_router_then);
+
 	Test.add_func ("/route", test_route);
 	Test.add_func ("/route/from_rule", test_route_from_rule);
 	Test.add_func ("/route/from_rule/null", test_route_from_rule_null);


### PR DESCRIPTION
This feature can produce a handling sequence by reusing the same matching callback for multiple handlers.

The `Route` has to know which HTTP method it is declared with, so its constructors has been slightly modified to require that information. It might even be possible to take rid of the method table since it is already in the route, but that would be for later if we have to rework the `Router` internals.

```vala
app.get ("", (req, res, next) => {
    next ();
}).then ((req, res) => {
    // ...
});