### PR TITLE
Use GLib.Parameter[] to store request params

### DIFF
--- a/docs/vsgi/server/scgi.rst
+++ b/docs/vsgi/server/scgi.rst
@@ -9,25 +9,10 @@ particularly simple to implement.
     SCGI is the recommended implementation and should be used when available as
     it takes the best out of GIO asynchronous API.
 
-The implementation uses a `GLib.ThreadedSocketService`_ to process multiple
-requests concurrently. It is critical to either avoid shared states or use
-`GLib.Mutex`_ or ``lock`` properly.
+The implementation uses a `GLib.SocketService`_ and processes multiple requests
+using non-blocking I/O.
 
-.. _GLib.ThreadedSocketService: http://valadoc.org/#!api=gio-2.0/GLib.ThreadedSocketService
-.. _GLib.Mutex: http://valadoc.org/#!api=glib-2.0/GLib.Mutex
-
-.. code:: vala
-
-    using VSGI.SCGI;
-
-    var shared_state = 5;
-
-    new Server ("org.vsgi.SCGI", (req, res) => {
-        // ...
-        lock (shared_state) {
-            shared_state++;
-        }
-    }).run ();
+.. _GLib.SocketService: http://valadoc.org/#!api=gio-2.0/GLib.SocketService
 
 Options
 -------
@@ -40,9 +25,6 @@ Options
 | ``--file-descriptor`` | 0       | listen to the provided file descriptor        |
 +-----------------------+---------+-----------------------------------------------+
 | ``--backlog``         | 0       | connection queue depth in the ``listen`` call |
-+-----------------------+---------+-----------------------------------------------+
-| ``--max-threads``     | -1      | the maximal number of threads to execute      |
-|                       |         | concurrently handling incoming clients        |
 +-----------------------+---------+-----------------------------------------------+
 
 In the case of ``--max-threads``, ``-1`` means no limit.

--- a/tests/route-test.vala
+++ b/tests/route-test.vala
@@ -202,3 +202,14 @@ public void test_route_fire () {
 
 	assert (setted);
 }
+
+/**
+ * @since 0.3
+ */
+public void test_route_to_path () {
+	var route = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
+
+	GLib.Parameter param = {"id", 5};
+
+	assert ("/5" == route.to_path ({param}));
+}

--- a/tests/router-test.vala
+++ b/tests/router-test.vala
@@ -30,6 +30,7 @@ public static void test_router_handle () {
 	router.handle (request, response);
 
 	HashTable<string, string>? @params;
+	assert (418 == response.status);
 	assert ("text/html" == response.headers.get_content_type (out @params));
 	assert (null != @params);
 	assert ("charset" in @params);

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -76,6 +76,7 @@ public int main (string[] args) {
 	Test.add_func ("/route/match", test_route_match);
 	Test.add_func ("/route/match/not_matching", test_route_match_not_matching);
 	Test.add_func ("/route/fire", test_route_match_not_matching);
+	Test.add_func ("/route/to_url", test_route_to_path);
 
 	Test.add_func ("/view/from_string", test_view_from_string);
 	Test.add_func ("/view/from_path", test_view_from_path);

--- a/wscript
+++ b/wscript
@@ -16,7 +16,6 @@ def configure(conf):
 
     conf.check_cfg(package='glib-2.0', atleast_version='2.32', uselib_store='GLIB', args='--cflags --libs')
     conf.check_cfg(package='gio-2.0', atleast_version='2.32', uselib_store='GIO', args='--cflags --libs')
-    conf.check_cfg(package='gthread-2.0', atleast_version='2.32', uselib_store='GTHREAD', args='--cflags --libs')
     conf.check_cfg(package='ctpl', atleast_version='0.3.3', uselib_store='CTPL', args='--cflags --libs')
     conf.check_cfg(package='gee-0.8', atleast_version='0.6.4', uselib_store='GEE', args='--cflags --libs')
     conf.check_cfg(package='libsoup-2.4', atleast_version='2.38',uselib_store='SOUP', args='--cflags --libs')
@@ -63,9 +62,8 @@ def build(bld):
         target       = 'valum',
         gir          = 'Valum-{}'.format(API_VERSION),
         source       = bld.path.ant_glob('src/*.vala'),
-        uselib       = ['GLIB', 'GIO', 'GTHREAD', 'CTPL', 'GEE', 'SOUP', 'FCGI', 'GCOV'],
+        uselib       = ['GLIB', 'GIO', 'CTPL', 'GEE', 'SOUP', 'FCGI', 'GCOV'],
         vapi_dirs    = ['vapi'],
-        thread       = True,
         header_path  = '${INCLUDEDIR}/valum',
         install_path = '${LIBDIR}')
 


### PR DESCRIPTION
The request paramters can integrate better with GObject if they consist of a list of `GLib.Parameter`. At first, it will be possible to unpack them in an arbitrary object and access the parameters by properties.

```vala
var obj = Object.newv (request.params);

var id = obj.property;
```

Then we could rework the current type system for parameters so that it can expand automatically the desired type.

```vala
var id = req.params[0].value.get_int ();
```

We could also use `Variant` serialization to store and extract data: http://valadoc.org/#!api=glib-2.0/GLib.Variant

 - type would become type format
 - values would be extracted seamlessly