### PR TITLE
Trailer in chunked encoding

### DIFF
--- a/docs/vsgi/converters.rst
+++ b/docs/vsgi/converters.rst
@@ -32,12 +32,15 @@ A typical utilisation would be to negociate a ``Content-Encoding: zlib`` header.
         res.body.write ("Hello world!".data);
     });
 
-ChunkedConverter
+ChunkedEncoder
 ----------------
 
-The ``ChunkedConverter`` will convert written data into chunks according to
+The ``ChunkedEncoder`` will convert written data into chunks according to
 `RFC2126 section 3.6.1`_. It is used automatically if the ``Transport-Encoding``
 header is set to ``chunked`` in the :doc:`response`.
+
+Additionally, if headers remain in the :doc:`response` headers, they will be
+written in the encoding trailer.
 
 .. _RFC2126 section 3.6.1: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6.1
 

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -15,6 +15,8 @@ app.get ("", (req, res) => {
 	var template = new View.from_stream (resources_open_stream ("/templates/home.html", ResourceLookupFlags.NONE));
 
 	template.to_stream (res.body);
+
+	res.headers.append ("Test", "test");
 });
 
 app.methods ({VSGI.Request.GET, VSGI.Request.POST}, "get-and-post", (req, res) => {

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -128,6 +128,8 @@ namespace VSGI {
 
 			var written = this.request.connection.output_stream.write (head, cancellable);
 
+			this.headers.clear ();
+
 			this.head_written = true;
 
 			return written;
@@ -151,6 +153,8 @@ namespace VSGI {
 			}
 
 			var written = yield this.request.connection.output_stream.write_async (head, priority, cancellable);
+
+			this.headers.clear ();
 
 			this.head_written = true;
 

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -148,7 +148,7 @@ namespace VSGI.Soup {
 				// filter the stream properly
 				if (this.request.http_version == HTTPVersion.@1_1 && this.headers.get_encoding () == Encoding.CHUNKED) {
 					this.filtered_body = new ConverterOutputStream (base.body,
-					                                                new ChunkedEncoder ());
+					                                                new ChunkedEncoder (this.headers));
 				} else {
 					this.filtered_body = base.body;
 				}

--- a/tests/vsgi/test_chunked_encoder.vala
+++ b/tests/vsgi/test_chunked_encoder.vala
@@ -5,7 +5,8 @@ using VSGI;
  */
 public void test_vsgi_chunked_encoder () {
 	var produced = new MemoryOutputStream (null, realloc, free);
-	var convert = new ConverterOutputStream (produced, new ChunkedEncoder ());
+	var convert = new ConverterOutputStream (produced,
+											 new ChunkedEncoder (new global::Soup.MessageHeaders (global::Soup.MessageHeadersType.RESPONSE)));
 
 	convert.write ("test".data);
 


### PR DESCRIPTION
This is a really handy feature from HTTP/1.1 that allow one to send outstanding headers in the encoding trailer.

I also fixed the `ChunkedEncoder` to encode the last chunk properly with its trailer.