### PR TITLE
Adds the '--debug' flag to produce coverage data from the Vala sources.

### DIFF
--- a/wscript
+++ b/wscript
@@ -47,10 +47,11 @@ def configure(conf):
 
     # other dependencies
     conf.check(lib='fcgi', uselib_store='FCGI', args='--cflags --libs')
+    conf.check(lib='gcov', mandatory=False, uselib_store='GCOV', args='--cflags --libs')
 
     if conf.options.enable_gcov:
-        conf.check(lib='gcov', uselib_store='GCOV', args='--cflags --libs')
         conf.env.append_unique('CFLAGS', ['-fprofile-arcs', '-ftest-coverage'])
+        conf.env.append_unique('VALAFLAGS', ['--debug'])
 
     # configure examples
     if conf.options.enable_examples:


### PR DESCRIPTION
It works, but there's some mix of c and vala sources, so the coverage value is not really representative.