### PR TITLE
Invert routing process

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,13 +50,16 @@ Recent dependencies will enable more advanced features:
 +-------------+---------+------------------------------------------------------+
 | gio-2.0     | >=2.40  | CLI arguments parsing                                |
 +-------------+---------+------------------------------------------------------+
-| gio-2.0     | >=2.44  | ``write_head_async`` in :doc:`vsgi/response`         |
+| gio-2.0     | >=2.44  | ``write_head_async`` in :doc:`vsgi/response` and     |
+|             |         | `GLib.strv_contains`_ to lookup methods when         |
+|             |         | producing an ``Allow`` header                        |
 +-------------+---------+------------------------------------------------------+
 | libsoup-2.4 | >=2.48  | new server API                                       |
 +-------------+---------+------------------------------------------------------+
 | libsoup-2.4 | >=2.50  | uses `Soup.ClientContext.steal_connection`_ directly |
 +-------------+---------+------------------------------------------------------+
 
+.. _GLib.strv_contains: http://valadoc.org/#!api=glib-2.0/GLib.strv_contains
 .. _Soup.ClientContext.steal_connection: http://valadoc.org/#!api=libsoup-2.4/Soup.ClientContext.steal_connection
 
 You can also install additional dependencies to build the examples, you will

--- a/src/route.vala
+++ b/src/route.vala
@@ -26,11 +26,11 @@ namespace Valum {
 		public weak Router router { construct; get; }
 
 		/**
-		 * HTTP method this is matching.
+		 * HTTP method this is matching or 'null' if it does apply.
 		 *
 		 * @since 0.2
 		 */
-		public string method { construct; get; }
+		public string? method { construct; get; }
 
 		/**
 		 * Create a Route using a custom matcher.
@@ -42,7 +42,7 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public Route (Router router, string method, owned MatcherCallback matcher, owned HandlerCallback callback) {
+		public Route (Router router, string? method, owned MatcherCallback matcher, owned HandlerCallback callback) {
 			Object (router: router, method: method);
 			this.match = (owned) matcher;
 			this.fire  = (owned) callback;
@@ -61,7 +61,7 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public Route.from_regex (Router router, string method, Regex regex, owned HandlerCallback callback) throws RegexError {
+		public Route.from_regex (Router router, string? method, Regex regex, owned HandlerCallback callback) throws RegexError {
 			Object (router: router, method: method);
 			this.fire = (owned) callback;
 
@@ -125,7 +125,7 @@ namespace Valum {
 		 * @param rule compiled down ot a regular expression and captures all
 		 *             paths if set to null
 		 */
-		public Route.from_rule (Router router, string method, string? rule, owned HandlerCallback callback) throws RegexError {
+		public Route.from_rule (Router router, string? method, string? rule, owned HandlerCallback callback) throws RegexError {
 			Object (router: router, method: method);
 			this.fire = (owned) callback;
 

--- a/src/router.vala
+++ b/src/router.vala
@@ -349,7 +349,11 @@ namespace Valum {
 				foreach (var route in this.routes.head) {
 					if (route.method != null &&                  // null method allow anything
 					    route.method != req.method &&            // exclude the request method (it's not allowed already)
+#if GLIB_2_44
 					    !strv_contains (allowed, route.method) && // skip already allowed method
+#else
+					    !string.joinv ("", allowed).contains (route.method) &&
+#endif
 					    route.match (req, stack)) {
 						allowed += route.method;
 					}

--- a/tests/test_router.vala
+++ b/tests/test_router.vala
@@ -490,7 +490,7 @@ public static void test_router_method_not_allowed () {
 	router.handle (request, response);
 
 	assert (response.status == 405);
-	assert ("PUT, GET" == response.headers.get_one ("Allow"));
+	assert ("GET, PUT" == response.headers.get_one ("Allow"));
 	assert (response.head_written);
 }
 
@@ -701,7 +701,7 @@ public static void test_router_status_propagates_error_message () {
 	var router = new Router ();
 
 	router.status (404, (req, res, next, stack) => {
-			var message = stack.pop_tail ();
+		var message = stack.pop_tail ();
 		res.status = 418;
 		assert ("The request URI http://localhost/ was not found." == message.get_string ());
 	});

--- a/wscript
+++ b/wscript
@@ -37,7 +37,7 @@ def configure(conf):
     if conf.check_cfg(package='gio-2.0', atleast_version='2.40', mandatory=False, uselib_store='GIO', args='--cflags --libs'):
         conf.env.append_unique('VALAFLAGS', ['--define=GIO_2_40'])
 
-    # gio (>=2.44) is necessary for 'write_all_async'
+    # gio (>=2.44) is necessary for 'write_all_async' and 'strv_contains'
     if conf.check_cfg(package='gio-2.0', atleast_version='2.44', mandatory=False, uselib_store='GIO', args='--cflags --libs'):
         conf.env.append_unique('VALAFLAGS', ['--define=GIO_2_44'])
 


### PR DESCRIPTION
Since the HTTP method have been moved to Route, there's no point to
maintain a mapping of methods to route queues in the Router.

No need to check if the mapping contains the method anymore, so the code
is much less complex.

Route method can be 'null' if matching the method does not apply. This
is used for status-based routes.

Modify the order of methods in 'Allow' header as they will respect the
order of declaration in the code.