### PR TITLE
Provide 'flatten' and 'flatten_async' in  Request

### DIFF
--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -151,6 +151,28 @@ a buffer:
 .. _GLib.MemoryOutputStream: http://valadoc.org/#!api=gio-2.0/GLib.MemoryOutputStream
 .. _Soup.Form: http://valadoc.org/#!api=libsoup-2.4/Soup.Form
 
+Accumulated body
+~~~~~~~~~~~~~~~~
+
+In some cases, it is practical to flatten the whole request body in a buffer
+in order to process it as a whole.
+
+.. warning::
+
+    Splicing an arbitrary-sized stream can pose a security threat named buffer
+    overflow. You must ensure that the server implementation has a hard limit
+    on submitted request size.
+
+The ``flatten`` and ``flatten`` functions flatten the request body into
+a buffer (a `GLib.MemoryOutputStream`_) and return the corresponding
+``uint8[]`` data buffer.
+
+.. code:: vala
+
+    app.post ("", (req, res) => {
+        var data = Soup.Form.decode ((string) req.flatten ());
+    });
+
 Multipart body
 ~~~~~~~~~~~~~~
 

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -81,12 +81,7 @@ app.scope ("cookie", (inner) => {
 	});
 
 	inner.post ("<name>", (req, res) => {
-		var @value = new MemoryOutputStream (null, realloc, free);
-
-		@value.splice (req.body, OutputStreamSpliceFlags.CLOSE_SOURCE);
-
-		var cookie = new Soup.Cookie (req.params["name"], (string) @value.data, "0.0.0.0", "/", 60);
-
+		var cookie = new Soup.Cookie (req.params["name"], (string) req.flatten (), "0.0.0.0", "/", 60);
 		res.headers.append ("Set-Cookie", cookie.to_set_cookie_header ());
 	});
 });
@@ -110,11 +105,7 @@ app.scope ("urlencoded-data", (inner) => {
 
 	inner.post ("", (req, res) => {
 		var writer = new DataOutputStream (res.body);
-		var data   = new MemoryOutputStream (null, realloc, free);
-
-		data.splice (req.body, OutputStreamSpliceFlags.CLOSE_SOURCE);
-
-		Soup.Form.decode ((string) data.get_data ()).foreach ((k, v) => {
+		Soup.Form.decode ((string) req.flatten ()).foreach ((k, v) => {
 			writer.put_string ("%s: %s".printf (k, v));
 		});
 	});

--- a/src/vsgi-request.vala
+++ b/src/vsgi-request.vala
@@ -170,6 +170,13 @@ namespace VSGI {
 		}
 
 		/**
+		 * @since 0.2
+		 */
+		public Bytes flatten_bytes (Cancellable? cancellable = null) throws IOError {
+			return new Bytes.take (flatten (cancellable));
+		}
+
+		/**
 		 * Buffer the body stream asynchronously.
 		 *
 		 * @see VSGI.Request.flatten_async
@@ -177,7 +184,8 @@ namespace VSGI {
 		 *
 		 * @return buffer containing the stream data
 		 */
-		public virtual async uint8[] flatten_async (int io_priority = GLib.Priority.DEFAULT, Cancellable? cancellable = null) throws IOError {
+		public virtual async uint8[] flatten_async (int io_priority = GLib.Priority.DEFAULT,
+		                                            Cancellable? cancellable = null) throws IOError {
 			var buffer = this.headers.get_encoding () == Encoding.CONTENT_LENGTH ?
 				new MemoryOutputStream (new uint8[this.headers.get_content_length ()], null, free) :
 				new MemoryOutputStream (null, realloc, free);
@@ -191,6 +199,14 @@ namespace VSGI {
 			data.length = (int) buffer.get_data_size ();
 
 			return data;
+		}
+
+		/**
+		 * @since 0.2
+		 */
+		public async Bytes flatten_bytes_async (int io_priority = GLib.Priority.DEFAULT,
+		                                        Cancellable? cancellable = null) throws IOError {
+			return new Bytes.take (yield flatten_async (io_priority, cancellable));
 		}
 	}
 }

--- a/src/vsgi-request.vala
+++ b/src/vsgi-request.vala
@@ -140,5 +140,57 @@ namespace VSGI {
 				return this.connection.input_stream;
 			}
 		}
+
+		/**
+		 * Buffer the body stream.
+		 *
+		 * This function consumes the body stream. Any subsequent calls will
+		 * yield an empty buffer.
+		 *
+		 * If the 'Content-Length' header is set, a fixed-size buffer is used
+		 * instead of dynamically resizing the buffer to fit the stream content.
+		 *
+		 * @since 0.2
+		 *
+		 * @return buffer containing the stream data
+		 */
+		public virtual uint8[] flatten (Cancellable? cancellable = null) throws IOError {
+			var buffer = this.headers.get_encoding () == Encoding.CONTENT_LENGTH ?
+				new MemoryOutputStream (new uint8[this.headers.get_content_length ()], null, free) :
+				new MemoryOutputStream (null, realloc, free);
+
+			buffer.splice (this.body,
+			               OutputStreamSpliceFlags.CLOSE_SOURCE | OutputStreamSpliceFlags.CLOSE_TARGET,
+			               cancellable);
+
+			var data = buffer.steal_data ();
+			data.length = (int) buffer.get_data_size ();
+
+			return data;
+		}
+
+		/**
+		 * Buffer the body stream asynchronously.
+		 *
+		 * @see VSGI.Request.flatten_async
+		 * @since 0.2
+		 *
+		 * @return buffer containing the stream data
+		 */
+		public virtual async uint8[] flatten_async (int io_priority = GLib.Priority.DEFAULT, Cancellable? cancellable = null) throws IOError {
+			var buffer = this.headers.get_encoding () == Encoding.CONTENT_LENGTH ?
+				new MemoryOutputStream (new uint8[this.headers.get_content_length ()], null, free) :
+				new MemoryOutputStream (null, realloc, free);
+
+			yield buffer.splice_async (this.body,
+			                           OutputStreamSpliceFlags.CLOSE_SOURCE | OutputStreamSpliceFlags.CLOSE_TARGET,
+			                           io_priority,
+			                           cancellable);
+
+			var data = buffer.steal_data ();
+			data.length = (int) buffer.get_data_size ();
+
+			return data;
+		}
 	}
 }

--- a/src/vsgi-soup.vala
+++ b/src/vsgi-soup.vala
@@ -94,7 +94,7 @@ namespace VSGI.Soup {
 			Object (connection: connection, message: msg);
 			this._query = query;
 #if SOUP_2_50
-			this._body  = new MemoryInputStream.from_data (msg.request_body.data, null);
+			this._body  = new MemoryInputStream.from_data (msg.request_body.flatten ().data, null);
 #endif
 		}
 
@@ -383,7 +383,7 @@ namespace VSGI.Soup {
 			public Connection (global::Soup.Server server, global::Soup.Message message) {
 				Object (server: server, message: message);
 
-				this._input_stream  = new MemoryInputStream.from_data (message.request_body.data, null);
+				this._input_stream  = new MemoryInputStream.from_data (message.request_body.flatten ().data, null);
 				this._output_stream = new MessageBodyOutputStream (message.response_body);
 
 				// prevent the server from completing the message

--- a/src/vsgi-soup.vala
+++ b/src/vsgi-soup.vala
@@ -111,6 +111,20 @@ namespace VSGI.Soup {
 			}
 		}
 #endif
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public override uint8[] flatten (Cancellable? cancellable = null) {
+			return message.request_body.data;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public override async uint8[] flatten_async (int io_priority = GLib.Priority.DEFAULT, Cancellable? cancellable = null) {
+			return message.request_body.data;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This feature provide `flatten` and `flatten_async` in `Request` to avoid the redundant and error-prone request body flattening.

The correct way to accumulate an `InputStream` have many drawbacks:
 
 - the stream must be spliced into a `MemoryOutputStream`
 - the `MemoyOutputStream` must be explicitly closed before calling `get_data`
 - the data buffer size must be set from the `MemoryOutputStream`
 - a fixed-size buffer can be used if the content length is known

Flattening could also be used for parts in a multipart message (see #81)