### PR TITLE
Spec fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 ### Valum ###
 build/
+/*.tar.bz2
 
 
 ### Sphinx ###
 docs/_build/
+
+
+### Editors ###
+*~
+.*.sw*
 
 
 ### Waf ###

--- a/valum.spec.in
+++ b/valum.spec.in
@@ -6,9 +6,13 @@ Summary:    Valum is a web micro-framework written in Vala
 Group:      Development/Libraries
 License:    LGPL
 URL:        https://github.com/valum-framework/valum
-Source0:    %{url}/archive/v%{version}.tar.gz
+Source0:    %{url}/releases/download/v%{version}/valum-%{version}.tar.bz2
 
-BuildRequires: vala vala-tools waf gobject-introspection-devel libgee-devel libsoup-devel ctpl-devel fcgi-devel
+BuildRequires: vala vala-tools
+BuildRequires: waf
+BuildRequires: gobject-introspection-devel
+BuildRequires: libgee-devel libsoup-devel
+BuildRequires: ctpl-devel fcgi-devel
 
 %description
 Valum is a web micro-framework able to create highly scalable expressive web

--- a/valum.spec.in
+++ b/valum.spec.in
@@ -6,9 +6,9 @@ Summary:    Valum is a web micro-framework written in Vala
 Group:      Development/Libraries
 License:    LGPL
 URL:        https://github.com/valum-framework/valum
-Source0:    %{name}-%{version}.tar.bz2
+Source0:    %{url}/archive/v%{version}.tar.gz
 
-BuildRequires: python, vala
+BuildRequires: vala vala-tools waf gobject-introspection-devel libgee-devel libsoup-devel ctpl-devel fcgi-devel
 
 %description
 Valum is a web micro-framework able to create highly scalable expressive web
@@ -42,4 +42,3 @@ LD_LIBRARY_PATH=%{buildroot}%{_libdir} ./build/tests/tests
 %files devel
 %{_datadir}/*
 %{_includedir}/*
-


### PR DESCRIPTION
Sorry if I'm overstepping editing your gitignore, if so cherry-picking that last commit should do the trick. I tested this just now and it builds in Copr a-ok. Also, the source URL is a valid URL, so now you can build with the slightly less arduous ```spectool -g -R build/valum.spec; rpmbuild -bs build/valum.spec```