### PR TITLE
Fix port command-line parsing in VSGI.SCGI.Server

### DIFF
--- a/src/vsgi-scgi.vala
+++ b/src/vsgi-scgi.vala
@@ -78,7 +78,7 @@ namespace VSGI.SCGI {
 			try {
 #if GIO_2_40
 				if (options.contains ("port")) {
-					var port = options.lookup_value ("port", VariantType.INT32).get_int16 ();
+					var port = (uint16) options.lookup_value ("port", VariantType.INT32).get_int32 ();
 					listener.add_inet_port (port, null);
 					command_line.print ("listening on tcp://0.0.0.0:%u\n", port);
 				} else if (options.contains ("file-descriptor")) {


### PR DESCRIPTION
On using the --port switch with a SCGI Server instance, the following
assertion error gets triggered:

```
(zervige:23094): GLib-CRITICAL **: g_variant_get_int16: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT16)' failed
```

This patch gets the int32 and casts to uint16