### PR TITLE
Logical expression for matching middlewares

### DIFF
--- a/examples/json/app.vala
+++ b/examples/json/app.vala
@@ -18,26 +18,9 @@
 using Valum;
 using VSGI.Soup;
 
-/**
- * Matching middleware that checks if the given request accepts an
- * 'application/json' response.
- */
-public bool accept_json (Request req) {
-	return req.headers.get_list ("Accept").contains ("application/json");
-}
-
-/**
- * Handling middleware that jumps to the next middleware.
- */
-public void skip (Request req, Response res, NextCallback next) {
-	next (req, res);
-}
-
 var app = new Router ();
 
-app.get ("", skip)
-   .and (accept_json)
-   .then ((req, res) => {
+app.get ("").and (accept ("application/json")).then ((req, res) => {
 	var builder   = new Json.Builder ();
 	var generator = new Json.Generator ();
 

--- a/examples/json/app.vala
+++ b/examples/json/app.vala
@@ -18,9 +18,26 @@
 using Valum;
 using VSGI.Soup;
 
+/**
+ * Matching middleware that checks if the given request accepts an
+ * 'application/json' response.
+ */
+public bool accept_json (Request req) {
+	return req.headers.get_list ("Accept").contains ("application/json");
+}
+
+/**
+ * Handling middleware that jumps to the next middleware.
+ */
+public void skip (Request req, Response res, NextCallback next) {
+	next (req, res);
+}
+
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("", skip)
+   .and (accept_json)
+   .then ((req, res) => {
 	var builder   = new Json.Builder ();
 	var generator = new Json.Generator ();
 

--- a/src/valum-middlewares.vala
+++ b/src/valum-middlewares.vala
@@ -29,6 +29,29 @@ namespace Valum {
 	}
 
 	/**
+	 * Produce a matching middleware that consist of the conjunction of
+	 * passed matchers.
+	 *
+	 * @since 0.3
+	 */
+	public MatcherCallback and (owned MatcherCallback left, owned MatcherCallback right) {
+		return (req, stack) => {
+			return left (req, stack) && right (req, stack);
+		};
+	}
+
+	/**
+	 * Produce a matching middleware that consist of the disjunction of
+	 * passed matchers.
+	 * @since 0.3
+	 */
+	public MatcherCallback or (owned MatcherCallback left, owned MatcherCallback right) {
+		return (req, stack) => {
+			return left (req, stack) || right (req, stack);
+		};
+	}
+
+	/**
 	 * Negociate an 'Accept' header against a provided content type.
 	 *
 	 * @since 0.3

--- a/src/valum-middlewares.vala
+++ b/src/valum-middlewares.vala
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using VSGI;
+
+namespace Valum {
+
+	/**
+	 * Produce a matching middleware that negates the provided middleware.
+	 *
+	 * @since 0.3
+	 */
+	public MatcherCallback not (owned MatcherCallback matcher)  {
+		return (req, stack) => { return ! matcher (req, stack); };
+	}
+
+	/**
+	 * Negociate an 'Accept' header against a provided content type.
+	 *
+	 * @since 0.3
+	 */
+	public MatcherCallback accept (string content_type) {
+		return (req) => {
+			return req.headers.get_list ("Accept").contains (content_type);
+		};
+	}
+
+	/**
+	 * Noop handling middleware that simply forwards the request and response
+	 * to the next handling middleware.
+	 *
+	 * It mainly serve as a default value and since it is optimized away by most
+	 * functions, so it's always better using it than skipping manually.
+	 *
+	 * @since 0.3
+	 */
+	public void noop (Request req, Response res, NextCallback next) {
+		next (req, res);
+	}
+}
+

--- a/src/valum-route.vala
+++ b/src/valum-route.vala
@@ -183,16 +183,12 @@ namespace Valum {
 
 		/**
 		 * Redefine this matcher callback to become a conjunction of itself and
-		 * the provided matcher.
+		 * the provided matcher using the {@link Valum.and} middleware.
 		 *
 		 * @since 0.3
 		 */
 		public Route and (owned MatcherCallback matcher) {
-			var initial_matcher = (owned) this.match;
-			this.match = (req, stack) => {
-				// TODO: reset the stack if the matcher fails
-				return initial_matcher (req, stack) && matcher (req, stack);
-			};
+			this.match = Valum.and ((owned) this.match, (owned) matcher);
 			return this;
 		}
 

--- a/src/valum-route.vala
+++ b/src/valum-route.vala
@@ -182,6 +182,17 @@ namespace Valum {
 		public HandlerCallback fire;
 
 		/**
+		 * @since 0.3
+		 */
+		public Route and (owned MatcherCallback matcher) {
+			var initial_matcher = this.match;
+			this.match = (req, stack) => {
+				return initial_matcher (req, stack) && matcher (req, stack);
+			};
+			return this;
+		}
+
+		/**
 		 * Pushes the handler in the {@link Router} queue to produce a sequence
 		 * of callbacks that reuses the same matcher.
 		 */

--- a/src/valum-route.vala
+++ b/src/valum-route.vala
@@ -182,11 +182,15 @@ namespace Valum {
 		public HandlerCallback fire;
 
 		/**
+		 * Redefine this matcher callback to become a conjunction of itself and
+		 * the provided matcher.
+		 *
 		 * @since 0.3
 		 */
 		public Route and (owned MatcherCallback matcher) {
-			var initial_matcher = this.match;
+			var initial_matcher = (owned) this.match;
 			this.match = (req, stack) => {
+				// TODO: reset the stack if the matcher fails
 				return initial_matcher (req, stack) && matcher (req, stack);
 			};
 			return this;
@@ -195,8 +199,17 @@ namespace Valum {
 		/**
 		 * Pushes the handler in the {@link Router} queue to produce a sequence
 		 * of callbacks that reuses the same matcher.
+		 *
+		 * If this handling callback is {@link Valum.noop}, it is automatically
+		 * replaced.
+		 *
+		 * @since 0.2
 		 */
 		public Route then (owned HandlerCallback handler) {
+			if (this.fire == noop) {
+				this.fire = (owned) handler;
+				return this;
+			}
 			return this.router.matcher (this.method, (owned) match, (owned) handler);
 		}
 	}

--- a/src/valum-router.vala
+++ b/src/valum-router.vala
@@ -65,56 +65,56 @@ namespace Valum {
 		/**
 		 * @since 0.0.1
 		 */
-		public new Route get (string? rule, owned HandlerCallback cb) throws RegexError {
+		public new Route get (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.GET, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route post (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route post (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.POST, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route put (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route put (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.PUT, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route delete (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route delete (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.DELETE, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route head (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route head (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.HEAD, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route options (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route options (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.OPTIONS, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public Route trace (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route trace (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.TRACE, rule, (owned) cb);
 		}
 
 		/**
 		 * @since 0.0.1
 		 */
-		public new Route connect (string? rule, owned HandlerCallback cb) throws RegexError {
+		public new Route connect (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.CONNECT, rule, (owned) cb);
 		}
 
@@ -123,7 +123,7 @@ namespace Valum {
 		 *
 		 * @since 0.0.1
 		 */
-		public Route patch (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route patch (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.method (Request.PATCH, rule, (owned) cb);
 		}
 
@@ -139,7 +139,7 @@ namespace Valum {
 		 * @param rule   rule
 		 * @param cb     callback used to process the pair of request and response.
 		 */
-		public Route method (string method, string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route method (string method, string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.route (new Route.from_rule (this, method, rule, (owned) cb));
 		}
 
@@ -148,7 +148,7 @@ namespace Valum {
 		 *
 		 * @since 0.1
 		 */
-		public Route[] all (string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route[] all (string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			return this.methods (Request.METHODS, rule, (owned) cb);
 		}
 
@@ -160,7 +160,7 @@ namespace Valum {
 		 * @param methods methods to which the callback will be bound
 		 * @param rule    rule
 		 */
-		public Route[] methods (string[] methods, string? rule, owned HandlerCallback cb) throws RegexError {
+		public Route[] methods (string[] methods, string? rule, owned HandlerCallback cb = noop) throws RegexError {
 			var routes = new Route[methods.length];
 			var i      = 0;
 			foreach (var method in methods) {
@@ -181,7 +181,7 @@ namespace Valum {
 		 * @param regex  regular expression matching the request path.
 		 * @param cb     callback used to process the pair of request and response.
 		 */
-		public Route regex (string method, Regex regex, owned HandlerCallback cb) throws RegexError {
+		public Route regex (string method, Regex regex, owned HandlerCallback cb = noop) throws RegexError {
 			return this.route (new Route.from_regex (this, method, regex, (owned) cb));
 		}
 
@@ -194,7 +194,7 @@ namespace Valum {
 		 * @param matcher callback used to match the request
 		 * @param cb      callback used to process the pair of request and response.
 		 */
-		public Route matcher (string method, owned MatcherCallback matcher, owned HandlerCallback cb) {
+		public Route matcher (string method, owned MatcherCallback matcher, owned HandlerCallback cb = noop) {
 			return this.route (new Route (this, method, (owned) matcher, (owned) cb));
 		}
 
@@ -221,14 +221,15 @@ namespace Valum {
 		 * @param status status handled
 		 * @param cb     callback used to handle the status
 		 */
-		public void status (uint status, owned HandlerCallback cb) {
+		public Route status (uint status, owned HandlerCallback cb = noop) {
 			if (!this.status_handlers.contains (status))
 				this.status_handlers[status] = new Queue<Route> ();
 
-			this.status_handlers[status].push_tail (new Route (this,
-			                                                   null,
-			                                                   () => { return true; },
-			                                                   (owned) cb));
+			var route = new Route (this, null, () => { return true; }, (owned) cb);
+
+			this.status_handlers[status].push_tail (route);
+
+			return route;
 		}
 
 		/**


### PR DESCRIPTION
The goal of this PR is to bring basic logical expression to compose matching middlewares. The typical usage would be to apply additional conditions on a rule-based matching.

```vala
app.get ("")
   .and (accept ("text/html"))
   .then ((req, res) => { /* produce an appropriate response... */ });
```

Considering the new possibilities that these expression brought, I also introduced a `noop` middleware that is used as a default handling callback in `Router`. It is carefully optimized away whenever possible.