### PR TITLE
Introduces middlewares for serving static content.

### DIFF
--- a/docs/middlewares/index.rst
+++ b/docs/middlewares/index.rst
@@ -12,6 +12,7 @@ from authentication to the delivery of a static resource.
     decode
     sequence
     server-sent-events
+    static
     status
     subdomain
 
@@ -84,3 +85,4 @@ success (or any other event) like it's the case for the ``accept`` middleware.
     }), (req, res) => {
         throw new ClientError.NOT_ACCEPTABLE ("We're only producing 'text/xml here!");
     });
+

--- a/docs/middlewares/static.rst
+++ b/docs/middlewares/static.rst
@@ -1,0 +1,116 @@
+Static Resource Delivery
+========================
+
+Middlewares in the ``Valum.Static`` namespace ensure delivery of static
+resources.
+
+::
+
+    using Valum.Static;
+
+As of convention, all middleware use the ``path`` context key to resolve the
+resource to be served. This can easily be specified using a rule parameter with
+the ``path`` type.
+
+For more flexibility, one can compute the ``path`` value and pass the control
+with ``next``. The following example obtain the key form the HTTP query:
+
+::
+
+    app.get ("/", sequence ((req, res, next, ctx) => {
+        ctx["path"] = req.lookup_query ("path") ?? "index.html";
+        return next ();
+    }, serve_from_file (File.new_for_uri ("resource://"))));
+
+If a resource is not available (eg. the file does not exist), the control will
+be forwarded to the next route. The :doc:`sequence` middleware should be used
+to turn that behaviour into a ``404 Not Found``.
+
+::
+
+    app.get ("/", sequence (serve_from_file (File.new_for_uri ("resource://")),
+                            (req, res, next, ctx) => {
+        throw new ClientError.NOT_FOUND ("The static resource '%s' were not found.", ctx["path"]);
+    }));
+
+GFile
+-----
+
+The ``serve_from_file`` middleware will serve resources relative to
+a `GLib.File`_ instance.
+
+::
+
+    app.get ("/static/<path:path>", serve_from_file (File.new_for_path ("static")));
+
+To deliver from the global resources, use the ``resource://`` scheme.
+
+.. _GLib.File: http://valadoc.org/#!api=gio-2.0/GLib.File
+
+::
+
+    app.get ("/static/<path:path>", serve_from_file (File.new_for_uri ("resource://static")));
+
+The ``ServeFlags.X_SENDFILE`` will only work for locally available files,
+meaning that `GLib.File.get_path`_ is non-null.
+
+.. _GLib.File.get_path: http://valadoc.org/#!api=gio-2.0/GLib.File.get_path
+
+Resource bundle
+---------------
+
+The ``serve_from_resource`` middleware is provided to serve a resource bundle
+(see `GLib.Resource`_) from a given prefix.
+
+.. _GLib.Resource: http://valadoc.org/#!api=gio-2.0/GLib.Resource
+
+::
+
+    app.get ("/static/<path:path>", Static.serve_from_resource (Resource.load ("resource"),
+                                                                "/static/"));
+
+The ``ServeFlags.ENABLE_LAST_MODIFIED`` is not supported since the necessary
+information cannot be determined.
+
+The ``ServeFlags.X_SENDFILE`` is not supported since contained resources are
+not represented on the filesystem.
+
+Options
+-------
+
+ETag
+~~~~
+
+If the ``ServeFlags.ENABLE_ETAG`` is specified, a checksum of the resource will
+be generated in the ``ETag`` header.
+
+If set and available, it will have precedence over
+``ServeFlags.ENABLE_LAST_MODIFIED`` described below.
+
+Last-Modified
+~~~~~~~~~~~~~
+
+Unlike ``ETag``, this caching feature is time-based and will indicate the last
+modification on the resource. This is only available for some GFile backend and
+will fallback to ``ETag`` if enabled as well.
+
+Specify the ``ServeFlags.ENABLE_LAST_MODIFIED`` to enable this feature.
+
+X-Sendfile
+~~~~~~~~~~
+
+If the application run under a HTTP server, it might be preferable to let it
+serve static resources directly.
+
+Public caching
+~~~~~~~~~~~~~~
+
+The ``ServeFlags.ENABLE_PUBLIC`` let intermediate HTTP servers cache the
+payload.
+
+Expose missing permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ServeFlags.FORBID_ON_MISSING_RIGHTS`` will trigger a ``403 Forbidden`` if
+rights are missing to read a file. This is not a default as it may expose
+information about the existence of certain files.

--- a/docs/recipes/static-resource.rst
+++ b/docs/recipes/static-resource.rst
@@ -18,6 +18,9 @@ This only applies to small and static resources as it will grow the size of the
 executable. Also, if the resources are compiled in your executable, changing
 them will require a recompilation.
 
+Middlewares are provided for that purpose, see `../middlewares/static` for more
+details.
+
 Integration
 -----------
 

--- a/examples/app/templates/home.html
+++ b/examples/app/templates/home.html
@@ -119,6 +119,7 @@
                 <li>
                   <a href="/negotiate-charset">negotiate charset (iso-8859-1)</a>
                 </li>
+                <li><a href="/static/css/bootstrap.min.css">static resources delivery</a></li>
               </ul>
               <footer>
                 <p class="text-center">

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -16,6 +16,7 @@
  */
 
 using Valum;
+using Valum.Static;
 using VSGI.FastCGI;
 
 public static int main (string[] args) {

--- a/examples/fastcgi/lighttpd.conf
+++ b/examples/fastcgi/lighttpd.conf
@@ -6,9 +6,10 @@ server.modules += ( "mod_fastcgi" )
 fastcgi.server = (
     "/" => (
         "valum" => (
-            "socket"      => var.CWD + "/valum.sock",
-            "bin-path"    => var.CWD + "/build/examples/fastcgi/fastcgi",
-            "check-local" => "disable"
+            "socket"            => var.CWD + "/valum.sock",
+            "bin-path"          => var.CWD + "/build/examples/fastcgi/fastcgi",
+            "check-local"       => "disable",
+            "allow-x-send-file" => "enable"
         )
     )
 )

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -192,7 +192,7 @@ namespace Valum.Static {
 	 * @param serve_flags flags for serving the resources
 	 */
 	public HandlerCallback serve_from_resource (Resource   resource,
-	                                            string     prefix,
+	                                            string     prefix      = "/",
 	                                            ServeFlags serve_flags = ServeFlags.NONE) {
 		// cache for already computed 'ETag' values
 		var etag_cache = new HashTable <string, string> (str_hash, str_equal);

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -174,6 +174,20 @@ namespace Valum.Static {
 	}
 
 	/**
+	 * @since 0.3
+	 */
+	public HandlerCallback serve_from_path (string path, ServeFlags serve_flags = ServeFlags.NONE) {
+		return serve_from_file (File.new_for_path (path), serve_flags);
+	}
+
+	/**
+	 * @since 0.3
+	 */
+	public HandlerCallback serve_from_uri (string uri, ServeFlags serve_flags = ServeFlags.NONE) {
+		return serve_from_file (File.new_for_uri (uri), serve_flags);
+	}
+
+	/**
 	 * Serve files from the provided {@link GLib.Resource} bundle.
 	 *
 	 * The 'ETag' header is obtained from a SHA1 checksum.

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -1,0 +1,244 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+using VSGI;
+
+/**
+ * Utilities to serve static resources.
+ *
+ * @since 0.3
+ */
+[CCode (gir_namespace = "ValumStatic", gir_version = "0.3")]
+namespace Valum.Static {
+
+	/**
+	 * Flags used to enble or disable options for serving static resources.
+	 *
+	 * @since 0.3
+	 */
+	[Flags]
+	public enum ServeFlags {
+		/**
+		 * @since 0.3
+		 */
+		NONE,
+		/**
+		 * Produce a 'ETag' header and raise {@link Valum.Redirection.NOT_MODIFIED}
+		 * if the resource has already been transmitted.
+		 *
+		 * @since 0.3
+		 */
+		ENABLE_ETAG,
+		/**
+		 * Produce a 'Last-Modified' header and raise {@link Valum.Redirection.NOT_MODIFIED}
+		 * if the resource has already been transmitted.
+		 *
+		 * @since 0.3
+		 */
+		ENABLE_LAST_MODIFIED,
+		/**
+		 * Indicate that the delivered resource can be cached by anyone using
+		 * the 'Cache-Control: public' header.
+		 *
+		 * @since 0.3
+		 */
+		ENABLE_CACHE_CONTROL_PUBLIC,
+		/**
+		 * Yield a {@link ClientError.FORBIDDEN} if rights are missing on the
+		 * resource rather than calling 'next'.
+		 *
+		 * @since 0.3
+		 */
+		FORBID_ON_MISSING_RIGHTS,
+		/**
+		 * If supported, generate a 'X-Sendfile' header instead of delivering
+		 * the actual resource in the response body.
+		 *
+		 * The absolute path as provided by {@link GLib.File.get_path} will be
+		 * produced in the 'X-Sendfile' header. It must therefore be accessible
+		 * for the HTTP server.
+		 *
+		 * If the file is not locally accessible, it will be spliced instead.
+		 *
+		 * @since 0.3
+		 */
+		X_SENDFILE
+	}
+
+	/**
+	 * Serve static files relative to a given root.
+	 *
+	 * The path to relative to the root is expected to be associated to the
+	 * 'path' key in the routing context.
+	 *
+	 * The path can be local or remote given that GVFS can be used.
+	 *
+	 * The 'ETag' header is obtained from {@link GLib.FileAttribute.ETAG_VALUE}.
+	 *
+	 * If the file is not found, the request is delegated to the next
+	 * middleware.
+	 *
+	 * If the file is not readable, a '403 Forbidden' is raised.
+	 *
+	 * @since 0.3
+	 *
+	 * @param root        path from which resources are resolved
+	 * @param serve_flags flags for serving the resources
+	 */
+	public HandlerCallback serve_from_file (File root, ServeFlags serve_flags = ServeFlags.NONE) {
+		return (req, res, next, ctx) => {
+			var file = root.resolve_relative_path (ctx["path"].get_string ());
+
+			try {
+				if (ServeFlags.ENABLE_ETAG in serve_flags) {
+					var etag = "\"%s\"".printf (file.query_info (FileAttribute.ETAG_VALUE,
+					                                             FileQueryInfoFlags.NONE).get_etag ());
+
+					if (etag == req.headers.get_one ("If-None-Match"))
+						throw new Redirection.NOT_MODIFIED ("");
+
+					res.headers.replace ("ETag", etag);
+				}
+
+				else if (ServeFlags.ENABLE_LAST_MODIFIED in serve_flags) {
+					var last_modified = file.query_info (FileAttribute.TIME_MODIFIED,
+					                                     FileQueryInfoFlags.NONE).get_modification_time ();
+
+					var if_modified_since = req.headers.get_one ("If-Modified-Since");
+
+					if (if_modified_since != null && new Soup.Date.from_string (if_modified_since).to_timeval ().tv_sec >= last_modified.tv_sec)
+						throw new Redirection.NOT_MODIFIED ("");
+
+					res.headers.replace ("Last-Modified",
+					                     new Soup.Date.from_time_t (last_modified.tv_sec).to_string (Soup.DateFormat.HTTP));
+				}
+
+				if (ServeFlags.ENABLE_CACHE_CONTROL_PUBLIC in serve_flags)
+					res.headers.append ("Cache-Control", "public");
+
+				var file_read_stream = file.read ();
+
+				// read 128 bytes for the content-type guess
+				var contents = new uint8[128];
+				file_read_stream.read_all (contents, null);
+
+				// reposition the stream
+				file_read_stream.seek (0, SeekType.SET);
+
+				bool uncertain;
+				res.headers.set_content_type (ContentType.guess (file.get_basename (), contents, out uncertain), null);
+
+				if (uncertain)
+					warning ("could not infer content type of file '%s' with certainty", file.get_uri ());
+
+				if (ServeFlags.X_SENDFILE in serve_flags && file.get_path () != null) {
+					res.headers.set_encoding (Soup.Encoding.NONE);
+					res.headers.replace ("X-Sendfile", file.get_path ());
+					return res.end ();
+				}
+
+				if (req.method == Request.HEAD)
+					return res.end ();
+
+				res.body.splice (file_read_stream, OutputStreamSpliceFlags.CLOSE_SOURCE);
+				return true;
+			} catch (FileError.ACCES fe) {
+				if (ServeFlags.FORBID_ON_MISSING_RIGHTS in serve_flags) {
+					throw new ClientError.FORBIDDEN ("You are cannot access this resource.");
+				} else {
+					return next ();
+				}
+			} catch (FileError.NOENT fe) {
+				return next ();
+			}
+		};
+	}
+
+	/**
+	 * Serve files from the provided {@link GLib.Resource} bundle.
+	 *
+	 * The 'ETag' header is obtained from a SHA1 checksum.
+	 *
+	 * To serve the global bundle, use {@link GLib.File.new_for_uri} along with
+	 * the 'resource://' scheme with {@link Valum.Static.serve_from_file}.
+	 *
+	 * [[http://valadoc.org/#!api=gio-2.0/GLib.Resource]]
+	 *
+	 * @see Valum.Static.serve_from_file
+	 * @see GLib.resources_open_stream
+	 * @see GLib.resources_lookup_data
+	 *
+	 * @since 0.3
+	 *
+	 * @param resource    resource bundle to serve
+	 * @param prefix      prefix from which resources are resolved in the
+	 *                    resource bundle; a valid prefix begin and start with a
+	 *                    '/' character
+	 * @param serve_flags flags for serving the resources
+	 */
+	public HandlerCallback serve_from_resource (Resource   resource,
+	                                            string     prefix,
+	                                            ServeFlags serve_flags = ServeFlags.NONE) {
+		// cache for already computed 'ETag' values
+		var etag_cache = new HashTable <string, string> (str_hash, str_equal);
+
+		return (req, res, next, ctx) => {
+			var path = "%s%s".printf (prefix, ctx["path"].get_string ());
+
+			Bytes lookup;
+			try {
+				lookup = resource.lookup_data (path, ResourceLookupFlags.NONE);
+			} catch (Error err) {
+				return next ();
+			}
+
+			if (ServeFlags.ENABLE_ETAG in serve_flags) {
+				var etag = path in etag_cache ?
+					etag_cache[path] :
+					"\"%s\"".printf (Checksum.compute_for_bytes (ChecksumType.SHA1, lookup));
+
+				etag_cache[path] = etag;
+
+				if (etag == req.headers.get_one ("If-None-Match"))
+					throw new Redirection.NOT_MODIFIED ("");
+
+				res.headers.replace ("ETag", etag);
+			}
+
+			if (ServeFlags.ENABLE_CACHE_CONTROL_PUBLIC in serve_flags)
+				res.headers.append ("Cache-Control", "public");
+
+			// set the content-type based on a good guess
+			bool uncertain;
+			res.headers.set_content_type (ContentType.guess (path, lookup.get_data (), out uncertain), null);
+			res.headers.set_content_length (lookup.get_size ());
+
+			if (uncertain)
+				warning ("could not infer content type of file '%s' with certainty", path);
+
+			if (req.method == Request.HEAD)
+				return res.end ();
+
+			var file = resource.open_stream (path, ResourceLookupFlags.NONE);
+
+			// transfer the file
+			res.body.splice (file, OutputStreamSpliceFlags.CLOSE_SOURCE);
+			return true;
+		};
+	}
+}

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -38,15 +38,20 @@ namespace Valum.Static {
 		 */
 		NONE,
 		/**
-		 * Produce a 'ETag' header and raise {@link Valum.Redirection.NOT_MODIFIED}
-		 * if the resource has already been transmitted.
+		 * Produce an 'ETag' header and raise a {@link Valum.Redirection.NOT_MODIFIED}
+		 * if the resource has already been transmitted. If not available, it
+		 * will fallback on either {@link Valum.Static.ServeFlags.ENABLE_LAST_MODIFIED}
+		 * or no caching at all.
 		 *
 		 * @since 0.3
 		 */
 		ENABLE_ETAG,
 		/**
-		 * Produce a 'Last-Modified' header and raise {@link Valum.Redirection.NOT_MODIFIED}
+		 * Produce a 'Last-Modified' header and raise a {@link Valum.Redirection.NOT_MODIFIED}
 		 * if the resource has already been transmitted.
+		 *
+		 * If {@link Valum.ServeFlags.ENABLE_ETAG} is specified and available,
+		 * it will be used instead.
 		 *
 		 * @since 0.3
 		 */
@@ -59,7 +64,7 @@ namespace Valum.Static {
 		 */
 		ENABLE_CACHE_CONTROL_PUBLIC,
 		/**
-		 * Yield a {@link ClientError.FORBIDDEN} if rights are missing on the
+		 * Raise a {@link ClientError.FORBIDDEN} if rights are missing on the
 		 * resource rather than calling 'next'.
 		 *
 		 * @since 0.3
@@ -71,9 +76,8 @@ namespace Valum.Static {
 		 *
 		 * The absolute path as provided by {@link GLib.File.get_path} will be
 		 * produced in the 'X-Sendfile' header. It must therefore be accessible
-		 * for the HTTP server.
-		 *
-		 * If the file is not locally accessible, it will be spliced instead.
+		 * for the HTTP server, otherwise it will silently fallback to serve the
+		 * resource directly.
 		 *
 		 * @since 0.3
 		 */
@@ -173,9 +177,6 @@ namespace Valum.Static {
 	 * Serve files from the provided {@link GLib.Resource} bundle.
 	 *
 	 * The 'ETag' header is obtained from a SHA1 checksum.
-	 *
-	 * To serve the global bundle, use {@link GLib.File.new_for_uri} along with
-	 * the 'resource://' scheme with {@link Valum.Static.serve_from_file}.
 	 *
 	 * [[http://valadoc.org/#!api=gio-2.0/GLib.Resource]]
 	 *


### PR DESCRIPTION
These are basic middlewares able to serve content from `GLib.File` and `GLib.Resource`. It supports `ETag`.

It could eventually be coupled with a middleware that supports HTTP caching for optimal performances.

With GVFS, it is even possible to serve remote files using various protocols.

There's a few thing to finish, mainly documentation and tests, before it can be merged.