### PR TITLE
Provide a routing context instead of a stack

### DIFF
--- a/docs/application.rst
+++ b/docs/application.rst
@@ -38,7 +38,7 @@ a :doc:`route` instance.
 
 .. code:: vala
 
-    app.get ("", (req, res, next, stack) => {
+    app.get ("", (req, res, next, context) => {
         res.body.write_all ("Hello world!".data, null);
     });
 
@@ -48,7 +48,7 @@ processing. The callback, named handler, receives four arguments:
 -  a :doc:`vsgi/request` that describes a resource being requested
 -  a :doc:`vsgi/response` that correspond to that resource
 -  a ``next`` continuation to `keep routing`
--  a routing ``stack`` to retrieve and store states from previous and for
+-  a routing ``context`` to retrieve and store states from previous and for
    following handlers
 
 Serving the application

--- a/docs/redirection-and-error.rst
+++ b/docs/redirection-and-error.rst
@@ -130,11 +130,11 @@ the :doc:`router` can handle them properly.
         throw new ClientError.NOT_FOUND ("");
     });
 
-During status handling, the error message will be pushed on the routing stack
-as a ``string``.
+During status handling, the error message will be pushed on the routing context
+as a ``string`` to the key ``message``.
 
 .. code:: vala
 
-    app.status (404, (req, res, next, stack) => {
-        var message = stack.pop_tail ().get_string ();
+    app.status (404, (req, res, next, context) => {
+        var message = context["message"].get_string ();
     });

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -26,8 +26,8 @@ public static int main (string[] args) {
 		res.body.write_all ("Hello world!".data, null);
 	});
 
-	app.get ("random/<int:size>", (req, res) => {
-		var size   = int.parse (req.params["size"]);
+	app.get ("random/<int:size>", (req, res, next, context) => {
+		var size   = int.parse (context["size"].get_string ());
 		var writer = new DataOutputStream (res.body);
 
 		for (; size > 0; size--) {

--- a/examples/memcached/app.vala
+++ b/examples/memcached/app.vala
@@ -21,8 +21,8 @@ using VSGI.Soup;
 var app       = new Router ();
 var memcached = new Memcached.Context.from_configuration ("--SERVER=localhost".data);
 
-app.get ("<key>", (req, res, next, stack) => {
-	var key = stack.pop_tail ().get_string ();
+app.get ("<key>", (req, res, next, context) => {
+	var key = context["key"].get_string ();
 
 	uint32 flags;
 	Memcached.ReturnCode error;
@@ -39,8 +39,8 @@ app.get ("<key>", (req, res, next, stack) => {
 	}
 });
 
-app.put ("<key>", (req, res, next, stack) => {
-	var key = stack.pop_tail ().get_string ();
+app.put ("<key>", (req, res, next, context) => {
+	var key = context["key"].get_string ();
 
 	var buffer = new MemoryOutputStream (null, realloc, free);
 
@@ -59,8 +59,8 @@ app.put ("<key>", (req, res, next, stack) => {
 	}
 });
 
-app.delete ("<key>", (req, res, next, stack) => {
-	var key = stack.pop_tail ().get_string ();
+app.delete ("<key>", (req, res, next, context) => {
+	var key = context["key"].get_string ();
 
 	var error = memcached.delete (key.data, 0);
 

--- a/examples/scgi/app.vala
+++ b/examples/scgi/app.vala
@@ -32,4 +32,4 @@ app.get ("async", (req, res) => {
 	res.body.write_all_async.begin ("Hello world!".data, Priority.DEFAULT, null);
 });
 
-new Server ("org.valum.example.SCGI", app.handle).run ();
+new Server ("org.valum.example.SCGI", app.handle).run ({"app", "--port", "3003"});

--- a/src/valum-context.vala
+++ b/src/valum-context.vala
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+
+/**
+ * Routing context that stores various states for middleware interaction.
+ *
+ * @since 0.3
+ */
+public class Valum.Context : Object {
+
+	/**
+	 * Internal mapping of states.
+	 */
+	private HashTable<string, Value?> states = new HashTable<string, Value?> (str_hash, str_equal);
+
+	/**
+	 * Parent's context from which missing keys are resolved.
+	 *
+	 * @since 0.3
+	 */
+	public Context? parent { construct; get; default = null; }
+
+	/**
+	 * Create a new root context.
+	 *
+	 * @since 0.3
+	 */
+	public Context () {
+
+	}
+
+	/**
+	 * Create a new child context.
+	 *
+	 * @since 0.3
+	 */
+	public Context.with_parent (Context parent) {
+		Object (parent: parent);
+	}
+
+	/**
+	 * Obtain a key from this context or its parent if it's not found.
+	 *
+	 * @since 0.3
+	 */
+	public new Value? @get (string key) {
+		return states[key] ?? (parent == null ? null : parent[key]);
+	}
+
+	/**
+	 * Set a key in this context.
+	 *
+	 * @since 0.3
+	 */
+	public new void @set (string key, Value? @value) {
+		states[key] = @value;
+	}
+
+	/**
+	 * Lookup if this context or its parent has a key.
+	 *
+	 * @since 0.3
+	 */
+	public bool contains (string key) {
+		return states.contains (key) || (parent != null && parent.contains (key));
+	}
+}

--- a/src/valum-route.vala
+++ b/src/valum-route.vala
@@ -106,17 +106,14 @@ namespace Valum {
 			// regex are optimized automatically :)
 			var prepared_regex = new Regex (pattern.str, RegexCompileFlags.OPTIMIZE);
 
-			this (router, method, (req, stack) => {
+			this (router, method, (req, context) => {
 				MatchInfo match_info;
 				if (prepared_regex.match (req.uri.get_path (), 0, out match_info)) {
 					if (captures.length () > 0) {
-						// populate the request parameters
-						var p = new HashTable<string, string?> (str_hash, str_equal);
+						// populate the context parameters
 						foreach (var capture in captures) {
-							p[capture] = match_info.fetch_named (capture);
-							stack.push_tail (match_info.fetch_named (capture));
+							context[capture] = match_info.fetch_named (capture);
 						}
-						req.params = p;
 					}
 					return true;
 				}
@@ -188,9 +185,9 @@ namespace Valum {
 		 * @since 0.2
 		 */
 		public Route then (owned HandlerCallback handler) {
-			return this.router.matcher (this.method, (req, stack) => {
-				// since the same matcher is shared, we preserve the stack intact
-				return match (req, new Queue<Value?> ());
+			return this.router.matcher (this.method, (req, context) => {
+				// since the same matcher is shared, we preserve the context intact
+				return match (req, new Context.with_parent (context));
 			}, (owned) handler);
 		}
 	}

--- a/src/valum-server-sent-events.vala
+++ b/src/valum-server-sent-events.vala
@@ -56,13 +56,13 @@ namespace Valum.ServerSentEvents {
 	 *
 	 * @param request    request this is responding to
 	 * @param send_event send a SSE message
-	 * @param stack
+	 * @param context
 	 *
 	 * @throws GLib.Error
 	 */
 	public delegate void EventStreamCallback (Request request,
 	                                          owned SendEventCallback send_event,
-	                                          Queue<Value?> stack) throws Error;
+	                                          Context context) throws Error;
 
 	/**
 	 * Middleware that create a context for sending Server-Sent Events.
@@ -83,7 +83,7 @@ namespace Valum.ServerSentEvents {
 	 * @param context context for sending events
 	 */
 	public HandlerCallback stream_events (owned EventStreamCallback context) {
-		return (req, res, next, stack) => {
+		return (req, res, next, _context) => {
 			HashTable<string, string> @params;
 			res.headers.get_content_type (out @params);
 			res.headers.set_content_type ("text/event-stream", @params);
@@ -111,7 +111,7 @@ namespace Valum.ServerSentEvents {
 
 					res.body.write_all (message.str.data, null);
 					res.body.flush ();
-				}, stack);
+				}, _context);
 			} catch (Error err) {
 				warning (err.message);
 			}

--- a/src/valum.vala
+++ b/src/valum.vala
@@ -35,17 +35,14 @@ namespace Valum {
 	public delegate void LoaderCallback (Router router);
 
 	/**
-	 * Match the request and populate the {@link VSGI.Request.params}.
-	 *
-	 * It is important for a matcher to populate the
-	 * {@link VSGI.Request.params} only if it matches the request.
+	 * Match the request and populate the initial {@link Valum.Context}.
 	 *
 	 * @since 0.1
 	 *
-	 * @param req           request being matched
-	 * @param initial_stack destination for the initial routing stack
+	 * @param req     request being matched
+	 * @param context initial context
 	 */
-	public delegate bool MatcherCallback (Request req, Queue<Value?> initial_stack);
+	public delegate bool MatcherCallback (Request req, Context context);
 
 	/**
 	 * Produce a matching middleware that negates the provided middleware.
@@ -91,21 +88,22 @@ namespace Valum {
 	 * @throws ServerError trigger a 5xx server error
 	 * @throws Error       any other error which will be handled as a {@link Valum.ServerError.INTERNAL}
 	 *
-	 * @param req   request being handled
-	 * @param res   response to send back to the requester
-	 * @param next  keep routing
-	 * @param stack routing stack as altered by the preceeding next invocation
-	 *              or initialized by the first {@link Valum.MatcherCallback}
+	 * @param req     request being handled
+	 * @param res     response to send back to the requester
+	 * @param next    keep routing
+	 * @param context routing context which parent is the context of the
+	 *                preceeding 'next' invocation or initialized by the
+	 *                first {@link Valum.MatcherCallback}
 	 */
 	public delegate void HandlerCallback (Request req,
 	                                      Response res,
 	                                      NextCallback next,
-	                                      Queue<Value?> stack) throws Informational,
-	                                                                  Success,
-	                                                                  Redirection,
-	                                                                  ClientError,
-	                                                                  ServerError,
-	                                                                  Error;
+	                                      Context context) throws Informational,
+	                                                              Success,
+	                                                              Redirection,
+	                                                              ClientError,
+	                                                              ServerError,
+	                                                              Error;
 
 	/**
 	 * Continuation passed in a {@link Valum.HandlerCallback} to *keep routing*

--- a/src/vsgi-request.vala
+++ b/src/vsgi-request.vala
@@ -62,16 +62,6 @@ namespace VSGI {
 		public const string[] METHODS = {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PATCH};
 
 		/**
-		 * Parameters for the request.
-		 *
-		 * These should be extracted from the URI path.
-		 *
-		 * @since 0.0.1
-		 */
-		[Deprecated (since = "0.2")]
-		public HashTable<string, string?>? @params { get; set; default = null; }
-
-		/**
 		 * Connection containing raw streams.
 		 *
 		 * @since 0.2

--- a/tests/cgi-test.vala
+++ b/tests/cgi-test.vala
@@ -43,7 +43,6 @@ public static void test_vsgi_cgi_request () {
 	assert (request.query.contains ("a"));
 	assert ("b" == request.query["a"]);
 	assert (3003 == request.uri.get_port ());
-	assert (null == request.params);
 	assert ("example.com" == request.headers.get_one ("Host"));
 	assert (connection.input_stream == request.body);
 }

--- a/tests/fastcgi-test.vala
+++ b/tests/fastcgi-test.vala
@@ -38,7 +38,6 @@ public static void test_vsgi_fastcgi_request () {
 	assert ("0.0.0.0" == request.uri.get_host ());
 	assert (3003 == request.uri.get_port ());
 	assert (null == request.query);
-	assert (null == request.params);
 	assert ("example.com" == request.headers.get_one ("Host"));
 	assert (connection.input_stream == request.body);
 }

--- a/tests/negociate-test.vala
+++ b/tests/negociate-test.vala
@@ -9,9 +9,9 @@ public void test_negociate () {
 
 	req.headers.append ("Accept", "text/html; q=0.9, text/xml; q=0");
 
-	assert (negociate ("Accept", "text/html") (req, null));
-	assert (!negociate ("Accept", "text/xml") (req, null));
-	assert (!negociate ("Accept-Encoding", "utf-8") (req, null));
+	assert (negociate ("Accept", "text/html") (req, new Context ()));
+	assert (!negociate ("Accept", "text/xml") (req, new Context ()));
+	assert (!negociate ("Accept-Encoding", "utf-8") (req, new Context ()));
 }
 
 

--- a/tests/route-test.vala
+++ b/tests/route-test.vala
@@ -22,12 +22,12 @@ using VSGI.Test;
  * @since 0.1
  */
 public void test_route () {
-	var router = new Router ();
-	var route  = new Route (router, "GET", (req) => { return true; }, (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var router  = new Router ();
+	var route   = new Route (router, "GET", (req) => { return true; }, (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+	var context = new Context ();
 
-	assert (route.match (req, stack));
+	assert (route.match (req, context));
 	assert (router == route.router);
 }
 
@@ -35,75 +35,64 @@ public void test_route () {
  * @since 0.1
  */
 public void test_route_from_rule () {
-	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
+	var route   = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var context = new Context ();
 
-	assert (route.match (request, stack));
-	assert (request.params != null);
-	assert (request.params["id"] == "5");
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert (route.match (request, context));
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_rule_null () {
-	var route  = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
+	var route   = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var context = new Context ();
 
-	assert (route.match (request, stack));
-	assert (request.params != null);
-	assert (request.params.contains ("path"));
-	assert ("5" == request.params["path"]);
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert (route.match (request, context));
+	assert (context.contains ("path"));
+	assert ("5" == context["path"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public static void test_route_from_rule_null_matches_empty_path () {
-	var route  = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
+	var route   = new Route.from_rule (new Router (), "GET", null, (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
-	var stack  = new Queue<Value?> ();
+	var context = new Context ();
 
-	assert (route.match (request, stack));
-	assert ("" == request.params["path"]);
-	assert ("" == stack.pop_tail ().get_string ());
+	assert (route.match (request, context));
+	assert ("" == context["path"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_rule_any () {
-	var route  = new Route.from_rule (new Router (), "GET", "<any:id>", (req, res) => {});
+	var route   = new Route.from_rule (new Router (), "GET", "<any:id>", (req, res) => {});
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var context = new Context ();
 
-	assert (route.match (request, stack));
+	assert (route.match (request, context));
 
-	assert (request.params != null);
-	assert (request.params["id"] == "5");
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_rule_without_captures () {
-	var route  = new Route.from_rule (new Router (), "GET", "", (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_rule (new Router (), "GET", "", (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
+	var context = new Context ();
 
-	assert (req.params == null);
-
-	var matches = route.match (req, stack);
+	var matches = route.match (req, context);
 
 	// ensure params are still null if there is no captures
 	assert (matches);
-	assert (req.params == null);
-	assert (stack.is_empty ());
 }
 
 /**
@@ -117,43 +106,31 @@ public void test_route_from_rule_undefined_type () {
  * @since 0.1
  */
 public void test_route_from_regex () {
-	var route  = new Route.from_regex (new Router (), "GET", /(?<id>\d+)/, (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_regex (new Router (), "GET", /(?<id>\d+)/, (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+	var context = new Context ();
 
-	assert (req.params == null);
-
-	var matches = route.match (req, stack);
+	var matches = route.match (req, context);
 
 	assert (matches);
-	assert (req.params != null);
-	assert (req.params["id"] == "5");
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
  * @since 0.2
  */
 public void test_route_from_regex_multiple_captures () {
-	var route  = new Route.from_regex (new Router (), "GET", /(?<action>\w+)\/(?<id>\d+)/, (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/user/5"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_regex (new Router (), "GET", /(?<action>\w+)\/(?<id>\d+)/, (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/user/5"));
+	var context = new Context ();
 
-	assert (req.params == null);
+	assert (route.match (req, context));
 
-	var matches = route.match (req, stack);
+	assert ("action" in context);
+	assert ("id" in context);
 
-	assert (matches);
-	assert (req.params != null);
-
-	assert ("action" in req.params);
-	assert ("id" in req.params);
-
-	assert ("user" == req.params["action"]);
-	assert ("5" == req.params["id"]);
-
-	assert ("5" == stack.pop_tail ().get_string ());
-	assert ("user" == stack.pop_tail ().get_string ());
+	assert ("user" == context["action"].get_string ());
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
@@ -164,66 +141,54 @@ public void test_route_from_regex_scoped () {
 
 	router.scopes.push_tail ("test");
 
-	var route  = new Route.from_regex (router, "GET", /(?<id>\d+)/, (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/test/5"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_regex (router, "GET", /(?<id>\d+)/, (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/test/5"));
+	var context = new Context ();
 
-	assert (req.params == null);
+	assert (route.match (req, context));
 
-	var matches = route.match (req, stack);
-
-	assert (matches);
-	assert (req.params != null);
-	assert (req.params["id"] == "5");
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_regex_without_captures () {
-	var route  = new Route.from_regex (new Router (), "GET", /.*/, (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_regex (new Router (), "GET", /.*/, (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
+	var context = new Context ();
 
-	var matches = route.match (req, stack);
+	var matches = route.match (req, context);
 
 	// ensure params are still null if there is no captures
-	assert (route.match (req, stack));
-	assert (req.params == null);
-	assert (stack.is_empty ());
+	assert (route.match (req, context));
 }
 
 /**
  * @since 0.1
  */
 public void test_route_match () {
-	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+	var context = new Context ();
 
-	assert (req.params == null);
-
-	var matches = route.match (req, stack);
+	var matches = route.match (req, context);
 
 	assert (matches);
-	assert (req.params != null);
-	assert (req.params.contains ("id"));
-	assert ("5" == stack.pop_tail ().get_string ());
+	assert (context.contains ("id"));
+	assert ("5" == context["id"].get_string ());
 }
 
 /**
  * @since 0.1
  */
 public void test_route_match_not_matching () {
-	var route  = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
-	var req    = new Request.with_uri (new Soup.URI ("http://localhost/home"));
-	var stack  = new Queue<Value?> ();
+	var route   = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {});
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
+	var context = new Context ();
 
 	// no match and params remains null
-	assert (route.match (req, stack) == false);
-	assert (req.params == null);
-	assert (stack.is_empty ());
+	assert (route.match (req, context) == false);
 }
 
 /**
@@ -234,9 +199,10 @@ public void test_route_fire () {
 	var route = new Route.from_rule (new Router (), "GET", "<int:id>", (req, res) => {
 		setted = true;
 	});
-	var req   = new Request.with_uri (new Soup.URI ("http://localhost/home"));
-	var res   = new Response (req);
-	var stack  = new Queue<Value?> ();
+
+	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
+	var res     = new Response (req);
+	var context = new Context ();
 
 	assert (setted == false);
 

--- a/tests/soup-test.vala
+++ b/tests/soup-test.vala
@@ -32,7 +32,6 @@ public static void test_vsgi_soup_request () {
 	assert ("0.0.0.0" == request.uri.get_host ());
 	assert (3003 == request.uri.get_port ());
 	assert (null == request.query);
-	assert (null == request.params);
 	assert (message.request_headers == request.headers);
 }
 

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -75,7 +75,7 @@ public int main (string[] args) {
 	Test.add_func ("/router/invoke/propagate_state", test_router_invoke_propagate_state);
 
 	Test.add_func ("/router/then", test_router_then);
-	Test.add_func ("/router/then/preserve_matching_stack", test_router_then_preserve_matching_stack);
+	Test.add_func ("/router/then/preserve_matching_context", test_router_then_preserve_matching_context);
 
 	Test.add_func ("/router/error", test_router_error);
 


### PR DESCRIPTION
The context provide a hierarchical mapping of states shared among handlers. It is possible to access the parent context.

```vala
var context = new Context ();

var context_with_parent = new Context.with_parent (context);
```

All operations are recursively applied. If a key is missing in the current context, it is retrieved in its parent.

```vala
app.use ((req, res, next, context) => {
    context["id"] = "6";
    next (req, res);
});

app.get ("user/<int:id>", (req, res, next, context) => {
    var user_id = context["id"].get_string ();
    context.parent["id"]; // refers to '6'
});
```

It completely replace `Request.params`, which has been removed.