### PR TITLE
Fix #137 Generate '*.typelib' for Python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ compiler:
 before_install:
     - sudo add-apt-repository --yes ppa:vala-team
     - sudo apt-get update --quiet
-    - sudo apt-get install --yes --force-yes valac-0.26 libglib2.0-bin
-      libglib2.0-dev libsoup2.4-dev libfcgi-dev python3-pip gcovr libgee-0.8-dev
-      libctpl-dev libjson-glib-dev libmemcached-dev libmarkdown2-dev
-      liblua5.2-dev
+    - sudo apt-get install --yes --force-yes valac-0.26 gobject-introspection
+      libglib2.0-bin libglib2.0-dev libsoup2.4-dev libfcgi-dev python3-pip
+      gcovr libgee-0.8-dev libctpl-dev libjson-glib-dev libmemcached-dev
+      libmarkdown2-dev liblua5.2-dev
     - sudo pip3 install meson sphinx sphinx_rtd_theme PyYAML
     - wget https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip
     - sudo unzip ninja-linux.zip -d /usr/local/bin

--- a/src/valum/meson.build
+++ b/src/valum/meson.build
@@ -25,7 +25,7 @@ valum_sources = files(
     'valum-subdomain.vala')
 valum_lib = library('valum-' + api_version, valum_sources,
                     dependencies: [glib, gobject, gio, soup, vsgi],
-                    vala_args: vala_defines,
+                    vala_args: ['--gir=Valum-@0@.gir'.format(api_version)] + vala_defines,
                     install: true)
 
 valum = declare_dependency(include_directories: include_directories('.'),
@@ -34,6 +34,17 @@ valum = declare_dependency(include_directories: include_directories('.'),
 install_headers(meson.current_build_dir() + '/valum-@0@.h'.format(api_version), subdir: 'valum-' + api_version)
 install_data(meson.current_build_dir() + '/valum-@0@.vapi'.format(api_version), install_dir: 'share/vala/vapi')
 install_data('valum-@0@.deps'.format(api_version), install_dir: 'share/vala/vapi')
+install_data(meson.current_build_dir() + '/valum-@0@@sha/Valum-@0@.gir'.format(api_version), install_dir: 'share/gir-1.0')
+
+g_ir_compiler = find_program('g-ir-compiler', required: false)
+if g_ir_compiler.found()
+    custom_target('Valum typelib', command: [g_ir_compiler, '--includedir', meson.current_build_dir() + '/../vsgi/vsgi-@0@@sha'.format(api_version), '@INPUT@', '--output', '@OUTPUT@'],
+                  input: meson.current_build_dir() + '/valum-@0@@sha/Valum-@0@.gir'.format(api_version),
+                  output: 'Valum-@0@.typelib'.format(api_version),
+                  install: true,
+                  install_dir: '@0@/girepository-1.0'.format(get_option('libdir')),
+                  depends: vsgi_typelib)
+endif
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(requires: 'vsgi-' + api_version,

--- a/src/valum/valum-server-sent-events.vala
+++ b/src/valum/valum-server-sent-events.vala
@@ -24,7 +24,7 @@ using VSGI;
  *
  * @since 0.3
  */
-[CCode (gir_namespace = "Valum.ServerSentEvents", gir_version = "0.3")]
+[CCode (gir_namespace = "Valum", gir_version = "0.3")]
 namespace Valum.ServerSentEvents {
 
 	/**

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -23,7 +23,7 @@ using VSGI;
  *
  * @since 0.3
  */
-[CCode (gir_namespace = "ValumStatic", gir_version = "0.3")]
+[CCode (gir_namespace = "Valum", gir_version = "0.3")]
 namespace Valum.Static {
 
 	/**

--- a/src/valum/valum.vala
+++ b/src/valum/valum.vala
@@ -21,7 +21,7 @@ using VSGI;
 /**
  * Valum is a web micro-framework written in Vala.
  */
-[CCode (gir_namespace = "Valum", gir_version = "0.2")]
+[CCode (gir_namespace = "Valum", gir_version = "0.3")]
 namespace Valum {
 
 	/**

--- a/src/vsgi/meson.build
+++ b/src/vsgi/meson.build
@@ -19,7 +19,7 @@ vsgi_sources = files(
     'vsgi-tee-output-stream.vala')
 vsgi_lib = library('vsgi-' + api_version, vsgi_sources,
                    dependencies: [glib, gobject, gio, gio_unix, gmodule, soup],
-                   vala_args: ['--pkg=posix'] + vala_defines,
+                   vala_args: ['--pkg=posix', '--gir=VSGI-@0@.gir'.format(api_version)] + vala_defines,
                    link_args: '-Wl,-rpath,$$ORIGIN/servers',
                    install: true,
                    install_rpath: '$ORIGIN/vsgi-@0@/servers'.format(api_version))
@@ -27,9 +27,19 @@ vsgi_lib = library('vsgi-' + api_version, vsgi_sources,
 vsgi = declare_dependency(include_directories: include_directories('.'),
                           link_with: vsgi_lib)
 
+g_ir_compiler = find_program('g-ir-compiler', required: false)
+if g_ir_compiler.found()
+    vsgi_typelib = custom_target('VSGI typelib', command: [g_ir_compiler, '@INPUT@', '--output', '@OUTPUT@'],
+                  input: meson.current_build_dir() + '/vsgi-@0@@sha/VSGI-@0@.gir'.format(api_version),
+                  output: 'VSGI-@0@.typelib'.format(api_version),
+                  install: true,
+                  install_dir: '@0@/girepository-1.0'.format(get_option('libdir')))
+endif
+
 install_headers(meson.current_build_dir() + '/vsgi-@0@.h'.format(api_version), subdir: 'vsgi-' + api_version)
 install_data(meson.current_build_dir() + '/vsgi-@0@.vapi'.format(api_version), install_dir: 'share/vala/vapi')
 install_data('vsgi-@0@.deps'.format(api_version), install_dir: 'share/vala/vapi')
+install_data(meson.current_build_dir() + '/vsgi-@0@@sha/VSGI-@0@.gir'.format(api_version), install_dir: 'share/gir-1.0')
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(requires: 'glib-2.0 gobject-2.0 gio-2.0 libsoup-2.4',

--- a/src/vsgi/vsgi-cgi.vala
+++ b/src/vsgi/vsgi-cgi.vala
@@ -26,6 +26,7 @@ using Soup;
  *
  * @since 0.3
  */
+[CCode (gir_namespace = "VSGI", gir_version = "0.3")]
 namespace VSGI.CGI {
 
 	/**

--- a/src/vsgi/vsgi-cookie-utils.vala
+++ b/src/vsgi/vsgi-cookie-utils.vala
@@ -22,7 +22,7 @@ using Soup;
  *
  * @since 0.2
  */
-[CCode (gir_namespace = "VsgiCookieUtils", gir_version = "0.2")]
+[CCode (gir_namespace = "VSGI", gir_version = "0.3")]
 namespace VSGI.CookieUtils {
 
 	/**

--- a/src/vsgi/vsgi-mock.vala
+++ b/src/vsgi/vsgi-mock.vala
@@ -20,6 +20,7 @@ using GLib;
 /**
  * Mock implementation of VSGI used for testing purposes.
  */
+[CCode (gir_namespace = "VSGI", gir_version = "0.3")]
 namespace VSGI.Mock {
 
 	/**

--- a/src/vsgi/vsgi.vala
+++ b/src/vsgi/vsgi.vala
@@ -26,7 +26,7 @@ using GLib;
  * Two implementation are available: libsoup built-in Soup.Server and FastCGI.
  * The latter integrates with pretty much any web server.
  */
-[CCode (gir_namespace = "VSGI", gir_version = "0.2")]
+[CCode (gir_namespace = "VSGI", gir_version = "0.3")]
 namespace VSGI {
 
 	/**


### PR DESCRIPTION
Fix GIR namespace to respect CamelCase style.

Generate '*.typelib' for VSGI, Valum and all available implementations.

It should work as well for Gjs.
