### PR TITLE
Enable --fatal-warnings and fix them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ compiler:
 before_install:
     - sudo add-apt-repository --yes ppa:vala-team
     - sudo apt-get update --quiet
-    - sudo apt-get install --yes --force-yes valac libglib2.0-bin libglib2.0-dev
-      libsoup2.4-dev libfcgi-dev python-pip valadoc
+    - sudo apt-get install --yes --force-yes valac-0.26 libglib2.0-bin
+      libglib2.0-dev libsoup2.4-dev libfcgi-dev python-pip valadoc
     - sudo pip install cpp-coveralls sphinx PyYAML
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ before_script:
 
 script:
     - ./build/tests/tests
+    - valadoc --pkg=glib-2.0 --pkg=gio-2.0 --pkg=gio-unix-2.0 --pkg=libsoup-2.4
+      --pkg=fcgi --target-glib=2.32 --directory=build/apidocs
+      --vapidir=/usr/share/vala-0.26/vapi --vapidir=src/vsgi-fastcgi
+      src/**/*.vala
 
 after_success:
     - coveralls --repo-token $COVERALLS_TOKEN --build-root build

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ The following dependencies are minimal to build the framework under Ubuntu
 +--------------+----------+
 | Package      | Version  |
 +==============+==========+
-| vala         | latest   |
+| vala         | >=0.26   |
 +--------------+----------+
 | python       | latest   |
 +--------------+----------+

--- a/src/valum/valum-router.vala
+++ b/src/valum/valum-router.vala
@@ -344,7 +344,7 @@ namespace Valum {
 		 * @param res   response for the context
 		 * @param next  callback to be invoked in the routing context
 		 */
-		public void invoke (Request req, Response res, owned NextCallback next) {
+		public void invoke (Request req, Response res, NextCallback next) {
 			try {
 				next (req, res);
 			} catch (Error err) {

--- a/src/vsgi-fastcgi/vsgi-fastcgi.vala
+++ b/src/vsgi-fastcgi/vsgi-fastcgi.vala
@@ -278,7 +278,7 @@ namespace VSGI.FastCGI {
 					// dispatch the app in the main loop
 					MainContext.@default ().invoke (() => {
 						dispatch (req, res);
-						return Source.REMOVE;
+						return false;
 					});
 				} while (true);
 

--- a/src/vsgi-http/vsgi-http.vala
+++ b/src/vsgi-http/vsgi-http.vala
@@ -366,14 +366,14 @@ namespace VSGI.HTTP {
 			foreach (var uri in this.server.get_uris ()) {
 				command_line.print ("listening on %s://%s:%u\n", uri.scheme, uri.host, uri.port);
 			}
+#else
+			this.server.run_async ();
+
+			command_line.print ("listening on http://0.0.0.0:%u\n", this.server.port);
+#endif
 
 			// keep the process alive
 			this.hold ();
-#else
-			command_line.print ("listening on http://0.0.0.0:%u\n", this.server.port);
-
-			this.server.run ();
-#endif
 
 			return 0;
 		}

--- a/src/vsgi-http/vsgi-http.vala
+++ b/src/vsgi-http/vsgi-http.vala
@@ -271,7 +271,6 @@ namespace VSGI.HTTP {
 				options.lookup_value ("file-descriptor", VariantType.INT32).get_int32 () : 0;
 #else
 			var port            = 3003;
-			var file_descriptor = 0;
 #endif
 
 #if GIO_2_40

--- a/src/vsgi-http/wscript
+++ b/src/vsgi-http/wscript
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
 
 def configure(cfg):
-    pass
+    # libsoup (>=2.38) to support TLS certificate
+    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.38', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
+        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_38'])
+
+    # libsoup (>=2.48) is necessary for the new server API
+    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.48', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
+        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_48'])
+
+    # libsoup (>=2.50) for steal_connection
+    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.50', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
+        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_50'])
 
 def build(bld):
     from waflib import Context

--- a/src/vsgi/wscript
+++ b/src/vsgi/wscript
@@ -3,7 +3,7 @@
 def configure(cfg):
     cfg.check_cfg(package='glib-2.0', atleast_version='2.32', uselib_store='GLIB', args='--cflags --libs')
     cfg.check_cfg(package='gio-2.0', atleast_version='2.32', uselib_store='GIO', args='--cflags --libs')
-    cfg.check_cfg(package='libsoup-2.4', atleast_version='2.38',uselib_store='SOUP', args='--cflags --libs')
+    cfg.check_cfg(package='libsoup-2.4', atleast_version='2.38', uselib_store='SOUP', args='--cflags --libs')
 
     # enable goodies in 'glib-2.0.vapi'
     cfg.env.append_unique('VALAFLAGS', ['--define=GLIB_2_30', '--define=GLIB_2_32'])
@@ -23,18 +23,6 @@ def configure(cfg):
     # gio (>=2.44) is necessary for 'write_all_async' and 'strv_contains'
     if cfg.check_cfg(package='gio-2.0', atleast_version='2.44', mandatory=False, uselib_store='GIO', args='--cflags --libs'):
         cfg.env.append_unique('VALAFLAGS', ['--define=GIO_2_44'])
-
-    # libsoup (>=2.38) to support TLS certificate
-    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.38', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
-        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_38'])
-
-    # libsoup (>=2.48) is necessary for the new server API
-    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.48', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
-        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_48'])
-
-    # libsoup (>=2.50) for steal_connection
-    if cfg.check_cfg(package='libsoup-2.4', atleast_version='2.50', mandatory=False, uselib_store='SOUP', args='--cflags --libs'):
-        cfg.env.append_unique('VALAFLAGS', ['--define=SOUP_2_50'])
 
 def build(bld):
     from waflib import Context

--- a/tests/cgi-test.vala
+++ b/tests/cgi-test.vala
@@ -94,7 +94,11 @@ public void test_vsgi_cgi_response () {
 	assert (Soup.Status.OK == response.status);
 
 	size_t bytes_written;
-	response.write_head (out bytes_written);
+	try {
+		response.write_head (out bytes_written);
+	} catch (IOError err) {
+		assert_not_reached ();
+	}
 	assert (18 == bytes_written);
 	assert (response.head_written);
 }

--- a/tests/chunked-encoder-test.vala
+++ b/tests/chunked-encoder-test.vala
@@ -24,13 +24,21 @@ public void test_vsgi_chunked_encoder () {
 	var produced = new MemoryOutputStream (null, realloc, free);
 	var convert = new ConverterOutputStream (produced, new ChunkedEncoder ());
 
-	convert.write ("test".data);
+	try {
+		convert.write ("test".data);
+	} catch (IOError err) {
+		assert_not_reached ();
+	}
 
 	assert (9 == produced.data_size);
 	for (int i = 0; i < produced.get_data ().length; i++)
 		assert ("4\r\ntest\r\n".data[i] == produced.get_data ()[i]);
 
-	convert.close ();
+	try {
+		convert.close ();
+	} catch (IOError err) {
+		assert_not_reached ();
+	}
 
 	assert (14 == produced.data_size);
 	for (int i = 9; i < produced.data_size; i++)

--- a/tests/negociate-test.vala
+++ b/tests/negociate-test.vala
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 using Valum;
 using VSGI.Mock;
 
@@ -10,17 +27,21 @@ public void test_negociate () {
 
 	req.headers.append ("Accept", "text/html; q=0.9, text/xml; q=0");
 
-	negociate ("Accept", "text/html", () => {}) (req, res, () => {
-		assert_not_reached ();
-	}, new Context ());
+	try {
+		negociate ("Accept", "text/html", () => {}) (req, res, () => {
+			assert_not_reached ();
+		}, new Context ());
 
-	negociate ("Accept", "text/xml", () => {
-		assert_not_reached ();
-	}) (req, res, () => {}, new Context ());
+		negociate ("Accept", "text/xml", () => {
+			assert_not_reached ();
+		}) (req, res, () => {}, new Context ());
 
-	negociate ("Accept-Encoding", "utf-8", () => {
+		negociate ("Accept-Encoding", "utf-8", () => {
+			assert_not_reached ();
+		}) (req, res, () => {}, new Context ());
+	} catch (Error err) {
 		assert_not_reached ();
-	}) (req, res, () => {}, new Context ());
+	}
 }
 
 

--- a/tests/route-test.vala
+++ b/tests/route-test.vala
@@ -33,30 +33,38 @@ public void test_route () {
  * @since 0.1
  */
 public void test_route_from_rule () {
-	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
-	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var context = new Context ();
+	try {
+		var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
+		var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+		var context = new Context ();
 
-	message (route.rule);
-	assert ("/<int:id>" == route.rule);
-	assert ("^/(?<id>\\w+)$" == route.regex.get_pattern ());
-	assert (RegexCompileFlags.OPTIMIZE in route.regex.get_compile_flags ());
-	assert (route.match (request, context));
-	assert ("5" == context["id"].get_string ());
+		message (route.rule);
+		assert ("/<int:id>" == route.rule);
+		assert ("^/(?<id>\\w+)$" == route.regex.get_pattern ());
+		assert (RegexCompileFlags.OPTIMIZE in route.regex.get_compile_flags ());
+		assert (route.match (request, context));
+		assert ("5" == context["id"].get_string ());
+	} catch (RegexError err) {
+		assert_not_reached ();
+	}
 }
 
 /**
  * @since 0.1
  */
 public void test_route_from_rule_without_captures () {
-	var route   = new RuleRoute (Method.GET, "/", null, (req, res) => {});
-	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
-	var context = new Context ();
+	try {
+		var route   = new RuleRoute (Method.GET, "/", null, (req, res) => {});
+		var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
+		var context = new Context ();
 
-	var matches = route.match (req, context);
+		var matches = route.match (req, context);
 
-	// ensure params are still null if there is no captures
-	assert (matches);
+		// ensure params are still null if there is no captures
+		assert (matches);
+	} catch (RegexError err) {
+		assert_not_reached ();
+	}
 }
 
 /**
@@ -64,12 +72,14 @@ public void test_route_from_rule_without_captures () {
  */
 public void test_route_from_rule_undefined_type () {
 	try {
-		var route  = new RuleRoute (Method.GET, "/<uint:unknown_type>", new HashTable<string, Regex> (str_hash,
-					str_equal), (req, res) => {});
+		new RuleRoute (Method.GET,
+		               "/<uint:unknown_type>",
+		               new HashTable<string, Regex> (str_hash, str_equal),
+		               (req, res) => {});
+		assert_not_reached ();
 	} catch (RegexError err) {
-		return;
+		assert (err is RegexError.COMPILE);
 	}
-	assert_not_reached ();
 }
 
 /**
@@ -113,7 +123,7 @@ public void test_route_from_regex_without_captures () {
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var context = new Context ();
 
-	var matches = route.match (req, context);
+	assert (route.match (req, context));
 
 	// ensure params are still null if there is no captures
 	assert (route.match (req, context));
@@ -123,47 +133,63 @@ public void test_route_from_regex_without_captures () {
  * @since 0.1
  */
 public void test_route_match () {
-	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
-	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
-	var context = new Context ();
+	try {
+		var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
+		var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
+		var context = new Context ();
 
-	var matches = route.match (req, context);
+		var matches = route.match (req, context);
 
-	assert (matches);
-	assert (context.contains ("id"));
-	assert ("5" == context["id"].get_string ());
+		assert (matches);
+		assert (context.contains ("id"));
+		assert ("5" == context["id"].get_string ());
+	} catch (RegexError err) {
+		assert_not_reached ();
+	}
 }
 
 /**
  * @since 0.1
  */
 public void test_route_match_not_matching () {
-	var types   = new HashTable<string, Regex> (str_hash, str_equal);
-	types["int"] = /\d+/;
-	var route   = new RuleRoute (Method.GET, "/<int:id>", types, (req, res) => {});
-	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
-	var context = new Context ();
+	try {
+		var types   = new HashTable<string, Regex> (str_hash, str_equal);
+		types["int"] = /\d+/;
+		var route   = new RuleRoute (Method.GET, "/<int:id>", types, (req, res) => {});
+		var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
+		var context = new Context ();
 
-	// no match and params remains null
-	assert (route.match (req, context) == false);
+		// no match and params remains null
+		assert (route.match (req, context) == false);
+	} catch (RegexError err) {
+		assert_not_reached ();
+	}
 }
 
 /**
  * @since 0.1
  */
 public void test_route_fire () {
-	var setted = false;
-	var route = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {
-		setted = true;
-	});
+	try {
+		var setted = false;
+		var route = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {
+			setted = true;
+		});
 
-	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
-	var res     = new Response (req);
-	var context = new Context ();
+		var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
+		var res     = new Response (req);
+		var context = new Context ();
 
-	assert (setted == false);
+		assert (setted == false);
 
-	route.fire (req, res, () => {}, null);
+		try {
+			route.fire (req, res, () => {}, context);
+		} catch (Error err) {
+			assert_not_reached ();
+		}
 
-	assert (setted);
+		assert (setted);
+	} catch (RegexError err) {
+		assert_not_reached ();
+	}
 }

--- a/tests/router-test.vala
+++ b/tests/router-test.vala
@@ -23,14 +23,9 @@ using VSGI.Mock;
  */
 public static void test_router () {
 	var router = new Router ();
-
-	try {
-		router.get ("<int:i>", (req, res) => {});
-		router.get ("<string:i>", (req, res) => {});
-		router.get ("<path:i>", (req, res) => {});
-	} catch (RegexError err) {
-		assert_not_reached ();
-	}
+	router.get ("<int:i>", (req, res) => {});
+	router.get ("<string:i>", (req, res) => {});
+	router.get ("<path:i>", (req, res) => {});
 }
 
 /**

--- a/tests/server-sent-events-test.vala
+++ b/tests/server-sent-events-test.vala
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
 using Valum;
 using Valum.ServerSentEvents;
 using VSGI.Mock;
@@ -18,15 +36,23 @@ public void test_server_sent_events_send () {
 
 	router.handle (req, res);
 
-	assert (res.body.close ());
+	try {
+		assert (res.body.close ());
+	} catch (IOError err) {
+		assert_not_reached ();
+	}
 
-	var expected_message = resources_lookup_data ("/data/server-sent-events/send-expected-message",
-	                                              ResourceLookupFlags.NONE);
+	try {
+		var expected_message = resources_lookup_data ("/data/server-sent-events/send-expected-message",
+													  ResourceLookupFlags.NONE);
 
-	var data = connection.memory_output_stream.steal_data ();
-	data.length = (int) connection.memory_output_stream.get_data_size ();
+		var data = connection.memory_output_stream.steal_data ();
+		data.length = (int) connection.memory_output_stream.get_data_size ();
 
-	assert (expected_message.compare (new Bytes (data)) == 0);
+		assert (expected_message.compare (new Bytes (data)) == 0);
+	} catch (Error err) {
+		assert_not_reached ();
+	}
 }
 
 public void test_server_sent_events_send_multiline () {
@@ -42,13 +68,21 @@ public void test_server_sent_events_send_multiline () {
 
 	router.handle (req, res);
 
-	assert (res.body.close ());
+	try {
+		assert (res.body.close ());
+	} catch (IOError err) {
+		assert_not_reached ();
+	}
 
-	var expected_message = resources_lookup_data ("/data/server-sent-events/send-multiline-expected-message",
-	                                              ResourceLookupFlags.NONE);
+	try {
+		var expected_message = resources_lookup_data ("/data/server-sent-events/send-multiline-expected-message",
+													  ResourceLookupFlags.NONE);
 
-	var data = connection.memory_output_stream.steal_data ();
-	data.length = (int) connection.memory_output_stream.get_data_size ();
+		var data = connection.memory_output_stream.steal_data ();
+		data.length = (int) connection.memory_output_stream.get_data_size ();
 
-	assert (expected_message.compare (new Bytes (data)) == 0);
+		assert (expected_message.compare (new Bytes (data)) == 0);
+	} catch (Error err) {
+		assert_not_reached ();
+	}
 }

--- a/tests/subdomain-test.vala
+++ b/tests/subdomain-test.vala
@@ -26,9 +26,13 @@ public void test_subdomain () {
 	var req   = new Request.with_uri (new Soup.URI ("http://127.0.0.1/"));
 	var res   = new Response (req);
 
-	subdomain ("api", () => {
+	try {
+		subdomain ("api", () => {
+			assert_not_reached ();
+		}, SubdomainFlags.NONE) (req, res, () => {}, new Context ());
+	} catch (Error err) {
 		assert_not_reached ();
-	}, SubdomainFlags.NONE) (req, res, () => {}, new Context ());
+	}
 }
 
 /**
@@ -39,18 +43,26 @@ public void test_subdomain_joker () {
 		var req   = new Request.with_uri (new Soup.URI ("http://api.example.com/"));
 		var res   = new Response (req);
 
-		subdomain("*", () => {}) (req, res, () => {
+		try {
+			subdomain("*", () => {}) (req, res, () => {
+				assert_not_reached ();
+			}, new Context ());
+		} catch (Error err) {
 			assert_not_reached ();
-		}, new Context ());
+		}
 	}
 
 	{
 		var req   = new Request.with_uri (new Soup.URI ("http://example.com/"));
 		var res   = new Response (req);
 
-		subdomain("*", () => {
+		try {
+			subdomain("*", () => {
+				assert_not_reached ();
+			}) (req, res, () => {}, new Context ());
+		} catch (Error err) {
 			assert_not_reached ();
-		}) (req, res, () => {}, new Context ());
+		}
 	}
 }
 
@@ -61,10 +73,14 @@ public void test_subdomain_strict () {
 	var req   = new Request.with_uri (new Soup.URI ("http://dev.api.example.com/"));
 	var res   = new Response (req);
 
-	subdomain ("api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
-	subdomain ("dev.api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
-	subdomain ("api", () => { assert_not_reached (); }, SubdomainFlags.STRICT) (req, res, () => {}, new Context ());
-	subdomain ("dev.api.example.com", () => {}, SubdomainFlags.STRICT, 0) (req, res, () => { assert_not_reached (); }, new Context ());
+	try {
+		subdomain ("api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
+		subdomain ("dev.api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
+		subdomain ("api", () => { assert_not_reached (); }, SubdomainFlags.STRICT) (req, res, () => {}, new Context ());
+		subdomain ("dev.api.example.com", () => {}, SubdomainFlags.STRICT, 0) (req, res, () => { assert_not_reached (); }, new Context ());
+	} catch (Error err) {
+		assert_not_reached ();
+	}
 }
 
 /**

--- a/tests/wscript
+++ b/tests/wscript
@@ -13,5 +13,6 @@ def build(bld):
         target       = 'tests',
         source       = bld.path.ant_glob('*.vala') + ['tests.gresource.xml'],
         use          = 'valum',
-        vapi_dirs    = '../src/vsgi-fastcgi',
         install_path = None)
+    from waflib.Tools import waf_unit_test
+    bld.add_post_fun(waf_unit_test.summary)

--- a/wscript
+++ b/wscript
@@ -15,6 +15,7 @@ def options(opt):
 def configure(conf):
     conf.load('compiler_c vala')
 
+    conf.check_vala(min_version=(0,26,0))
     conf.check(lib='gcov', mandatory=False, uselib_store='GCOV', args='--cflags --libs')
     conf.find_program('valadoc', mandatory=False)
 
@@ -25,7 +26,7 @@ def configure(conf):
                                       '-Wno-unused-variable',
                                       '-Wno-unused-but-set-variable',
                                       '-Wno-unused-function'])
-    conf.env.append_unique('VALAFLAGS', ['--fatal-warnings'])
+    conf.env.append_unique('VALAFLAGS', ['--enable-experimental', '--enable-deprecated', '--fatal-warnings'])
 
     if conf.options.enable_gcov:
         conf.env.append_unique('CFLAGS', ['-fprofile-arcs', '-ftest-coverage'])

--- a/wscript
+++ b/wscript
@@ -17,7 +17,6 @@ def configure(conf):
 
     conf.check_vala(min_version=(0,26,0))
     conf.check(lib='gcov', mandatory=False, uselib_store='GCOV', args='--cflags --libs')
-    conf.find_program('valadoc', mandatory=False)
 
     conf.recurse(['src', 'docs', 'tests'])
 
@@ -40,20 +39,6 @@ def configure(conf):
 def build(bld):
     bld.load('compiler_c vala')
     bld.recurse(['src', 'data', 'docs', 'tests'])
-
-    # generate the api documentation
-    if bld.env.VALADOC:
-        bld.load('valadoc')
-        bld(
-            features        = 'valadoc',
-            packages        = ['glib-2.0', 'gio-2.0', 'gio-unix-2.0', 'libsoup-2.4', 'fcgi'],
-            files           = bld.path.ant_glob('src/**/*.vala'),
-            vala_defines    = 'GLIB_2_32',
-            package_name    = 'valum',
-            package_version = VERSION,
-            vapi_dirs       = 'src/vsgi-fastcgi',
-            output_dir      = 'apidocs',
-            force           = True)
 
     # build examples
     if bld.env.ENABLE_EXAMPLES:

--- a/wscript
+++ b/wscript
@@ -25,6 +25,7 @@ def configure(conf):
                                       '-Wno-unused-variable',
                                       '-Wno-unused-but-set-variable',
                                       '-Wno-unused-function'])
+    conf.env.append_unique('VALAFLAGS', ['--fatal-warnings'])
 
     if conf.options.enable_gcov:
         conf.env.append_unique('CFLAGS', ['-fprofile-arcs', '-ftest-coverage'])


### PR DESCRIPTION
I would be great to lower the requirements for `valac` down to something like 0.14 since it's what's available on Precise.