### PR TITLE
vsgi: Make 'ApplicationCallback' return true if handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ using VSGI.HTTP;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-    res.body.write_all ("Hello world!".data, null);
+    return res.body.write_all ("Hello world!".data, null);
 });
 
 new Server ("org.valum.example.App", app.handle).run ();

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -39,7 +39,7 @@ a :doc:`route` instance.
 ::
 
     app.get ("", (req, res, next, context) => {
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
 Every route declaration has a callback associated that does the request
@@ -77,7 +77,7 @@ a :doc:`vsgi/request` and :doc:`vsgi/response`.
 
     new Server ("org.valum.example.App", (req, res) => {
         res.status = 200;
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     }).run ({"app", "--port", "3003"});
 
 Usually, you would only pass the CLI arguments to ``run``, so that your runtime

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -33,7 +33,7 @@ the latest changes in the framework.
     var app = new Router ();
 
     app.get ("", (req, res) => {
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
     new Server (app.handle).run ({"app", "--port", "3003"});

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -48,11 +48,11 @@ spending time on producing a body that won't be considered is important.
     res.headers.set_content_type ("text/html", null);
 
     if (req.method == "HEAD") {
-        res.write_head ();
-        return;
+        size_t bytes_written;
+        return res.write_head (out bytes_written);
     }
 
-    res.body.write_all ("<!DOCTYPE html><html></html>");
+    return res.body.write_all ("<!DOCTYPE html><html></html>");
 
 Use the ``construct`` block to perform post-initialization work. It will be
 called independently of how the object is constructed.

--- a/docs/recipes/json.rst
+++ b/docs/recipes/json.rst
@@ -35,7 +35,7 @@ stream synchronously it in the :doc:`../vsgi/response` body.
         generator.root   = user.get_root ();
         generator.pretty = false;
 
-        generator.to_stream (res.body);
+        return generator.to_stream (res.body);
     });
 
 Serialize GObject
@@ -70,7 +70,7 @@ a JSON object from the encountered properties.
         generator.root   = Json.gobject_serialize (user);
         generator.pretty = false;
 
-        generator.to_stream (res.body);
+        return generator.to_stream (res.body);
     });
 
 With middlewares, you can split the process in multiple reusable steps to avoid
@@ -89,7 +89,7 @@ code duplication. They are described in the :doc:`../router` document.
         // fetch the user
         app.get ("<username>", (req, res, next, context) => {
             context["user"] = new User.from_username (context["username"].get_string ());
-            next (req, res);
+            return next (req, res);
         });
 
         // update model data
@@ -121,7 +121,7 @@ code duplication. They are described in the :doc:`../router` document.
 
             context["user"] = user;
 
-            next (req, res);
+            return next (req, res);
         });
 
         // serialize to JSON any provided GObject
@@ -133,7 +133,7 @@ code duplication. They are described in the :doc:`../router` document.
 
             res.headers.set_content_type ("application/json", null);
 
-            generator.to_stream (res.body);
+            return generator.to_stream (res.body);
         });
     });
 
@@ -153,6 +153,6 @@ expecting a considerable user input.
         context["user"] = user;
 
         // execute 'next' in app context
-        app.invoke (req, res, next);
+        return app.invoke (req, res, next);
     });
 

--- a/docs/recipes/persistence.rst
+++ b/docs/recipes/persistence.rst
@@ -42,7 +42,7 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
         Memcached.ReturnCode error;
         var value = memcached.get ("hello", out flags, out error);
 
-        res.body.write_all (value, null);
+        return res.body.write_all (value, null);
     });
 
     app.post ("<key>", (req, res) => {
@@ -56,5 +56,5 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
         Memcached.ReturnCode error;
         var value = memcached.get ("hello", out flags, out error);
 
-        res.body.write_all (value, null);
+        return res.body.write_all (value, null);
     });

--- a/docs/recipes/scripting.rst
+++ b/docs/recipes/scripting.rst
@@ -37,7 +37,7 @@ Lua
         res.body.write_all (some_lua_code.data, null);
 
         // evaluate a file containing Lua code
-        res.body.write_all (lua.do_file ("scripts/hello.lua").data, null);
+        return res.body.write_all (lua.do_file ("scripts/hello.lua").data, null);
     });
 
     new Server ("org.valum.example.Lua", app.handle).run ();
@@ -64,8 +64,7 @@ Scheme can be used to produce template or facilitate computation.
 ::
 
     app.get ("hello.scm", (req, res) => {
-        var writer = new DataOutputStream (res.body);
-        writer.put_string (scm.run ("scripts/hello.scm"));
+        return res.body.write_all (scm.run ("scripts/hello.scm").data, null);
     });
 
 Scheme code:

--- a/docs/redirection-and-error.rst
+++ b/docs/redirection-and-error.rst
@@ -123,7 +123,7 @@ the :doc:`router` can handle them properly.
 ::
 
     app.get ("", (req, res, next) => {
-        next (req, res); // will throw a 404
+        return next (req, res); // will throw a 404
     });
 
     app.get ("", (req, res) => {

--- a/docs/route.rst
+++ b/docs/route.rst
@@ -119,8 +119,7 @@ and optimized.
 ::
 
     app.regex (Request.GET, new Regex ("home/?", RegexCompileFlags.OPTIMIZE), (req, res) => {
-        var writer = new DataOutputStream (res.body);
-        writer.put_string ("Matched using a regular expression.");
+        return res.body.write_all ("Matched using a regular expression.".data, true);
     });
 
 Named captures are registered in the routing context.
@@ -145,8 +144,7 @@ A matcher consist of a callback matching a given ``Request`` object.
     MatcherCallback matcher = (req) => { req.path == "/custom-matcher"; };
 
     app.matcher (Method.GET, matcher, (req, res) => {
-        var writer = new DataOutputStream (res.body);
-        writer.put_string ("Matched using a custom matcher.");
+        return res.body.write_all ("Matched using a custom matcher.".data, null);
     });
 
 You could, for instance, match the request if the user is an administrator and

--- a/docs/router.rst
+++ b/docs/router.rst
@@ -22,7 +22,7 @@ It can be performed automatically with ``Router.use``:
         var params = new HashTable<string, string> (str_hash, str_equal);
         params["charset"] = "iso-8859-1";
         res.headers.set_content_type ("text/xhtml+xml", params);
-        next (req, res);
+        return next (req, res);
     });
 
 Routing context
@@ -38,11 +38,12 @@ context if it's missing.
 
     app.get ("", (req, res, next, context) => {
         context["some key"] = "some value";
-        next (req, res);
+        return next (req, res);
     });
 
     app.get ("", (req, res, next, context) => {
         var some_value = context["some key"]; // or context.parent["some key"]
+        return return res.body.write_all (some_value.data, null);
     });
 
 HTTP methods
@@ -53,7 +54,7 @@ Callback can be connected to HTTP methods via a list of helpers having the
 
 ::
 
-    app.get ("rule", (req, res, next) => {});
+    app.get ("rule", (req, res, next) => { return false; });
 
 The rule has to respect the rule syntax described in :doc:`route`. It will be
 compiled down to a regex which named groups are made accessible in the context.
@@ -87,6 +88,8 @@ the ``application/x-www-form-urlencoded`` body of the :doc:`vsgi/request`.
 
         // assuming you have a session implementation in your app
         var session = new Session.authenticated_by (username, password);
+
+        return true;
     });
 
 It is also possible to use a custom HTTP method via the ``method``
@@ -161,12 +164,12 @@ invoked to jump to the next status handler in the queue.
 ::
 
     app.status (Soup.Status.NOT_FOUND, (req, res, next) => {
-        next (req, res);
+        return next (req, res);
     });
 
     app.status (Soup.Status.NOT_FOUND, (req, res) => {
         res.status = 404;
-        res.body.write_all ("Not found!".data, null);
+        return res.body.write_all ("Not found!".data, null);
     });
 
 :doc:`redirection-and-error` can be thrown during the status handling, they
@@ -210,6 +213,7 @@ It provides a nice way to ignore passively unrecoverable errors.
                 throw new IOError.FAILED ("I/O failed undesirably.")
             });
         });
+        return true;
     });
 
 If the routing context is lost, any operation can still be performed within
@@ -311,7 +315,7 @@ matching route.
 
     app.get ("", (req, res, next) => {
         message ("pre");
-        next (req, res); // keep routing
+        return next (req, res); // keep routing
     });
 
     app.get ("", (req, res) => {
@@ -327,7 +331,7 @@ Filters
 ::
 
     app.get ("", (req, res, next) => {
-        next (req, new ConvertedResponse (res, new ZlibCompressor (ZlibCompressorFormat.GZIP)));
+        return next (req, new ConvertedResponse (res, new ZlibCompressor (ZlibCompressorFormat.GZIP)));
     });
 
     app.get ("", (req, res) => {
@@ -345,10 +349,10 @@ processing for a resource using handling middlewares.
 
     app.get ("admin", (req, res, next) => {
         // authenticate user...
-        next (req, res);
+        return next (req, res);
     }).then ((req, res, next) => {
         // produce sensitive data...
-        next (req, res);
+        return next (req, res);
     }).then ((req, res) => {
         // produce the response
     });
@@ -368,7 +372,7 @@ with custom and default status code handlers. It constitute an entry point for
 
     app.get ("", (req, res, next) => {
         res.body.write_all_async ("Hello world!".data, Priority.DEFAULT, null, () => {
-            app.invoke (req, res, next);
+            return app.invoke (req, res, next);
         });
     });
 
@@ -401,7 +405,7 @@ responses designed for non-human client.
     });
 
     app.status (Status.NOT_ACCEPTABLE, (req, res, next, context) => {
-        res.body.write_all ("<p>%s</p>".printf (context["message"].get_string ()).data, null);
+        return res.body.write_all ("<p>%s</p>".printf (context["message"].get_string ()).data, null);
     });
 
 Middleware
@@ -458,7 +462,7 @@ conditionally to a matching middleware.
 
     app.use ((req, res, next) => {
         // executed on every request
-        next (req, res);
+        return next (req, res);
     });
 
 The following example shows a middleware that provide a compressed stream over
@@ -468,11 +472,11 @@ the :doc:`vsgi/response` body.
 
     app.use ((req, res, next) => {
         res.headers.replace ("Content-Encoding", "gzip");
-        next (req, new ConvertedResponse (res, new ZLibCompressor (ZlibCompressorFormat.GZIP)));
+        return next (req, new ConvertedResponse (res, new ZLibCompressor (ZlibCompressorFormat.GZIP)));
     });
 
     app.get ("home", (req, res) => {
-        res.body.write_all ("Hello world!".data, null); // transparently compress the output
+        return res.body.write_all ("Hello world!".data, null); // transparently compress the output
     });
 
 If this is wrapped in a function, which is typically the case, it can even be
@@ -482,13 +486,13 @@ used directly from the handler.
 
     HandlerCallback compress = (req, res, next) => {
         res.headers.replace ("Content-Encoding", "gzip");
-        next (req, new ConvertedResponse (res, new ZLibCompressor (ZlibCompressorFormat.GZIP));
+        return next (req, new ConvertedResponse (res, new ZLibCompressor (ZlibCompressorFormat.GZIP));
     };
 
     app.get ("home", compress);
 
     app.get ("home", (req, res) => {
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
 Alternatively, a handling middleware can be used directly instead of being
@@ -497,7 +501,7 @@ attached to a :doc:`route`, the processing will happen in a ``NextCallback``.
 ::
 
     app.get ("home", (req, res, next, context) => {
-        compress (req, res, (req, res) => {
-            res.body.write_all ("Hello world!".data, null);
+        return compress (req, res, (req, res) => {
+            return res.body.write_all ("Hello world!".data, null);
         }, new Context.with_parent (context));
     });

--- a/docs/vsgi/connection.rst
+++ b/docs/vsgi/connection.rst
@@ -31,5 +31,6 @@ require the status to be part of the response headers.
         message.write_all ("Content-Type: text/plain\r\n");
         message.write_all ("\r\n".data);
         message.write_all ("Hello world!".data);
+        return true;
     });
 

--- a/docs/vsgi/converters.rst
+++ b/docs/vsgi/converters.rst
@@ -30,7 +30,7 @@ A typical utilisation would be to negociate a ``Content-Encoding: zlib`` header.
         // the body will be compressed transparently
         res.body = new ConverterOutputStream (res.body, new ZLibCompressor ());
 
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
 ChunkedConverter

--- a/docs/vsgi/filters.rst
+++ b/docs/vsgi/filters.rst
@@ -27,6 +27,6 @@ You can use any :doc:`converters` provided by GLib or VSGI with ease.
         res = new ConvertedResponse (res, new ZlibCompressor (ZlibCompressorFormat.GZIP));
         res.status = 200;
         res.headers.append ("Content-Encoding", "gzip");
-        res.body.write_all ("Hello world!".data);
+        return res.body.write_all ("Hello world!".data);
     });
 

--- a/docs/vsgi/index.rst
+++ b/docs/vsgi/index.rst
@@ -26,7 +26,8 @@ Entry point
 
 The entry point of a VSGI application is type-compatible with the
 ``ApplicationCallback`` delegate. It is a function of two arguments:
-a :doc:`request` and a :doc:`response`.
+a :doc:`request` and a :doc:`response` that return a boolean indicating if the
+request has been or will be processed.
 
 ::
 
@@ -34,7 +35,11 @@ a :doc:`request` and a :doc:`response`.
 
     new Server ("org.vsgi.App", (req, res) => {
         // process the request and produce the response...
+        return true;
     }).run ();
+
+If an application indicate that the request has not been processed, it's up to
+the server implementation to decide what will happen.
 
 Accessing the :doc:`response` ``body`` for the first time will write the status
 line and headers synchronously in the connection stream before returning an
@@ -57,7 +62,7 @@ the first time.
         res.status = 200;
         res.headers.append ("Transfer-Encoding", "chunked");
         // chunked encoding will be applied
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
 Asynchronous processing

--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -25,11 +25,11 @@ Additionally, an array of supported HTTP methods is provided by
 ::
 
     if (req.method == Request.GET) {
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     }
 
     if (req.method == Request.POST) {
-        res.body.splice (req.body, OutputStreamSpliceFlags.NONE);
+        return res.body.splice (req.body, OutputStreamSpliceFlags.NONE);
     }
 
     if (req.method in Request.METHODS) {
@@ -82,6 +82,7 @@ from the ``headers`` property.
 
     new Server ("org.vsgi.App", (req) => {
         var accept = req.headers.get_one ("Accept");
+        return true;
     });
 
 libsoup-2.4 provides a very extensive set of utilities to process the
@@ -138,7 +139,9 @@ which is submitted by web browsers.
 
             // decode the data
             var data = Soup.Form.decode (data);
-        })
+        });
+
+        return true;
     });
 
 Some considerations should be taken when accumulating the request body into
@@ -171,6 +174,7 @@ a buffer (a `GLib.MemoryOutputStream`_) and return the corresponding
 
     app.post ("", (req, res) => {
         var data = Soup.Form.decode ((string) req.flatten ());
+        return true;
     });
 
 Multipart body

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -25,6 +25,7 @@ The status code will be written in the response with ``write_head`` or
 
     new Server ("org.vsgi.App", (req, res) => {
         res.status = Soup.Status.MALFORMED;
+        return true;
     });
 
 Headers
@@ -40,6 +41,7 @@ The response headers can be accessed as a `Soup.MessageHeaders`_ from the
     new Server ("org.vsgi.App", (req, res) => {
         res.status = Soup.Status.OK;
         res.headers.set_content_type ("text/plain", null);
+        return res.body.write_all ("Hello world!".data, null);
     });
 
 Headers can be written in the response by invoking ``write_head`` or its
@@ -92,7 +94,7 @@ HTTP/1.1 specifications such as chunked encoding.
     var body = new ConverterOutputStream (res.body,
                                           new CharsetConverter (res.body, "iso-8859-1", "utf-8"));
 
-    body.write_all ("Omelette du fromâge!", null);
+    return body.write_all ("Omelette du fromâge!", null);
 
 Additionally, some filters are applied automatically if the ``Transfer-Encoding``
 header is set. The obtained `GLib.OutputStream`_ will be wrapped appropriately
@@ -105,7 +107,7 @@ so that the application can transparently produce its output.
 ::
 
     res.headers.append ("Transfer-Encoding", "chunked");
-    res.body.write_all ("Hello world!".data, null);
+    return res.body.write_all ("Hello world!".data, null);
 
 Asynchronous write
 ~~~~~~~~~~~~~~~~~~
@@ -129,6 +131,7 @@ The simplest thing to overcome this limitation is to reference the
             // the reference to the response has persisted
             var written = res.body.write_async.end (result);
         });
+        return true;
     });
 
 Closing the response
@@ -161,5 +164,7 @@ the last ``write`` operation and the end of the processing.
         res.body.close ();
 
         Mailer.send ("johndoe@example.com", "Had to close that stream mate!");
+
+        return true;
     });
 

--- a/docs/vsgi/server/cgi.rst
+++ b/docs/vsgi/server/cgi.rst
@@ -48,6 +48,8 @@ callback, the connection will be kept alive until both are freed.
         Idle.add (() => {
             req.body.write_all ("Hello world!".data, null);
         });
+
+        return true;
     };
 
     server = new Server ("org.vsgi.CGI", app);

--- a/docs/vsgi/server/http.rst
+++ b/docs/vsgi/server/http.rst
@@ -13,7 +13,7 @@ application or spawn workers in production.
 
     new Server ("org.vsgi.HTTP", () => {
         res.status = Soup.Status.OK;
-        res.body.write_all ("Hello world!".data, null);
+        return res.body.write_all ("Hello world!".data, null);
     }).run ({"app", "--port", "3003"});
 
 Options

--- a/docs/vsgi/server/index.rst
+++ b/docs/vsgi/server/index.rst
@@ -66,7 +66,7 @@ written in a usual ``main`` function.
     public static int main (string[] args) {
         return new Server ("org.vsgi.App", (req, res) => {
             res.status = Soup.Status.OK;
-            res.body.write_all ("Hello world!".data, null);
+            return res.body.write_all ("Hello world!".data, null);
         }).run (args);
     }
 

--- a/examples/api-interaction/app.vala
+++ b/examples/api-interaction/app.vala
@@ -39,7 +39,7 @@ app.get ("", (req, res) => {
 
 			var main = parser.get_root ().get_object ().get_object_member ("main");
 
-			res.body.write_all ("""
+			return res.body.write_all ("""
 			<h1>Weather in Montreal</h1>
 			<dl>
 			  <dt>Humidity</dt><dd>%s</dd>
@@ -55,6 +55,7 @@ app.get ("", (req, res) => {
 						main.get_string_member ("temp_min")).data, null);
 		});
 	});
+	return true;
 });
 
 new Server ("org.valum.example.WeatherAPI", app.handle).run ({"app", "--all"});

--- a/examples/cgi/app.vala
+++ b/examples/cgi/app.vala
@@ -21,7 +21,7 @@ using VSGI.CGI;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	return res.body.write_all ("Hello world!".data, null);
 });
 
 new Server ("org.valum.example.CGI", app.handle).run ();

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -23,7 +23,7 @@ public static int main (string[] args) {
 
 	// default route
 	app.get ("", (req, res) => {
-		res.body.write_all ("Hello world!".data, null);
+		return res.body.write_all ("Hello world!".data, null);
 	});
 
 	app.get ("random/<int:size>", (req, res, next, context) => {
@@ -34,6 +34,8 @@ public static int main (string[] args) {
 			// write byte to byte
 			writer.put_uint32 (Random.next_int ());
 		}
+
+		return true;
 	});
 
 	return new Server ("org.valum.example.FastCGI", app.handle).run (args);

--- a/examples/genie/app.gs
+++ b/examples/genie/app.gs
@@ -6,5 +6,5 @@ init
 
   new VSGI.HTTP.Server ("org.valum.example.Genie", app.handle).run ({"app", "--all"})
 
-def home (req : VSGI.Request, res : VSGI.Response) raises IOError
-  res.body.write_all ("Hello world!".data, null)
+def home (req : VSGI.Request, res : VSGI.Response) : bool raises IOError
+  return res.body.write_all ("Hello world!".data, null)

--- a/examples/json/app.vala
+++ b/examples/json/app.vala
@@ -42,7 +42,7 @@ app.get ("", (req, res) => {
 
 	res.headers.set_content_type ("application/json", null);
 
-	generator.to_stream (res.body);
+	return generator.to_stream (res.body);
 });
 
 new Server ("org.valum.example.JSON", app.handle).run ({"app", "--all"});

--- a/examples/lua/app.vala
+++ b/examples/lua/app.vala
@@ -29,7 +29,7 @@ app.get ("", (req, res) => {
 		require "markdown"
 		return markdown('## Hello from lua.eval!')""");
 
-	res.body.write_all (vm.to_string (-1).data, null);
+	return res.body.write_all (vm.to_string (-1).data, null);
 });
 
 new Server ("org.valum.example.Lua", app.handle).run ({"app", "--all"});

--- a/examples/markdown/app.vala
+++ b/examples/markdown/app.vala
@@ -9,7 +9,7 @@ app.get ("", (req, res) => {
 	doc.compile (DocumentFlags.EMBED);
 	string markdown;
 	doc.document (out markdown);
-	res.body.write_all (markdown.data, null);
+	return res.body.write_all (markdown.data, null);
 });
 
 new Server ("org.valum.example.Markdown", app.handle).run ();

--- a/examples/memcached/app.vala
+++ b/examples/memcached/app.vala
@@ -30,8 +30,7 @@ app.get ("<key>", (req, res, next, context) => {
 
 	switch (error) {
 		case Memcached.ReturnCode.SUCCESS:
-			res.body.write_all (data, null);
-			break;
+			return res.body.write_all (data, null);
 		case Memcached.ReturnCode.NOTFOUND:
 			throw new ClientError.NOT_FOUND ("key '%s' was not found", key);
 		default:

--- a/examples/modular-app/admin-router.vala
+++ b/examples/modular-app/admin-router.vala
@@ -28,12 +28,11 @@ public class AdminRouter : Router {
 	/**
 	 * Verify the user credentials and perform an authentication.
 	 */
-	public void authenticate (Request req, Response res, NextCallback next) throws Error {
+	public bool authenticate (Request req, Response res, NextCallback next) throws Error {
 		string @value;
 		req.lookup_signed_cookie ("session", ChecksumType.SHA256, "impossible to break".data, out @value);
 		if (@value == "admin") {
-			next (req, res);
-			return;
+			return next (req, res);
 		}
 
 		if (req.method == Request.POST) {
@@ -42,13 +41,12 @@ public class AdminRouter : Router {
 				var session_cookie = new Soup.Cookie ("session", "admin", "", "/admin/view", Soup.COOKIE_MAX_AGE_ONE_HOUR);
 				CookieUtils.sign (session_cookie, ChecksumType.SHA256, "impossible to break".data);
 				res.headers.append ("Set-Cookie", session_cookie.to_set_cookie_header ());
-				next (req, res);
-				return;
+				return next (req, res);
 			}
 		}
 
 		res.headers.set_content_type ("text/html", null);
-		res.body.write_all ("""
+		return res.body.write_all ("""
 		<!DOCTYPE html>
 		<html>
 		  <head>
@@ -67,8 +65,8 @@ public class AdminRouter : Router {
 	/**
 	 * Restricted content.
 	 */
-	public void view (Request req, Response res, NextCallback next, Context ctx) throws Error {
+	public bool view (Request req, Response res, NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
-		res.body.write ("Hello admin!".data, null);
+		return res.body.write_all ("Hello admin!".data, null);
 	}
 }

--- a/examples/modular-app/app.vala
+++ b/examples/modular-app/app.vala
@@ -21,7 +21,7 @@ using VSGI.HTTP;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all (
+	return res.body.write_all (
 	"""
 	<!DOCTYPE html>
 	<html>

--- a/examples/modular-app/user-router.vala
+++ b/examples/modular-app/user-router.vala
@@ -24,8 +24,8 @@ public class UserRouter : Router {
 		get ("user/<int:id>", view);
 	}
 
-	public void view (Request req, Response res, NextCallback next, Context ctx) throws Error {
+	public bool view (Request req, Response res, NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
-		res.body.write_all ("Hello, user %s!".printf (ctx["id"].get_string ()).data, null);
+		return res.body.write_all ("Hello, user %s!".printf (ctx["id"].get_string ()).data, null);
 	}
 }

--- a/examples/scgi/app.vala
+++ b/examples/scgi/app.vala
@@ -21,15 +21,17 @@ using VSGI.SCGI;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	return res.body.write_all ("Hello world!".data, null);
 });
 
 app.post ("", (req, res) => {
 	res.body.splice (req.body, OutputStreamSpliceFlags.NONE);
+	return true;
 });
 
 app.get ("async", (req, res) => {
 	res.body.write_all_async.begin ("Hello world!".data, Priority.DEFAULT, null);
+	return true;
 });
 
 new Server ("org.valum.example.SCGI", app.handle).run ({"app"});

--- a/src/valum/valum-negociate.vala
+++ b/src/valum/valum-negociate.vala
@@ -34,9 +34,9 @@ namespace Valum {
 		return (req, res, next, stack) => {
 			var header = req.headers.get_list (header_name);
 			if (header != null && header_parse_quality_list (header, null).find_custom (expectation, strcmp) != null) {
-				forward (req, res, next, stack);
+				return forward (req, res, next, stack);
 			} else {
-				next (req, res);
+				return next (req, res);
 			}
 		};
 	}

--- a/src/valum/valum-route.vala
+++ b/src/valum/valum-route.vala
@@ -77,9 +77,9 @@ namespace Valum {
 		public Route then (owned HandlerCallback handler) {
 			var old_fire = (owned) _fire;
 			_fire = (req, res, next, context) => {
-				old_fire (req, res, (req, res) => {
+				return old_fire (req, res, (req, res) => {
 					// since the same matcher is shared, we preserve the context intact
-					handler (req, res, next, context);
+					return handler (req, res, next, context);
 				}, context);
 			};
 			return this;

--- a/src/valum/valum-route.vala
+++ b/src/valum/valum-route.vala
@@ -53,12 +53,12 @@ namespace Valum {
          *
 		 * @since 0.0.1
 		 */
-		public void fire (Request req, Response res, NextCallback next, Context ctx) throws Success,
+		public bool fire (Request req, Response res, NextCallback next, Context ctx) throws Success,
 		                                                                                    Redirection,
 		                                                                                    ClientError,
 		                                                                                    ServerError,
 																							Error {
-			_fire (req, res, next, ctx);
+			return _fire (req, res, next, ctx);
 		}
 
 		/**

--- a/src/valum/valum-server-sent-events.vala
+++ b/src/valum/valum-server-sent-events.vala
@@ -97,7 +97,7 @@ namespace Valum.ServerSentEvents {
 
 				// don't hang the user agent on a 'HEAD' request
 				if (req.method == Request.HEAD)
-					return;
+					return true;
 
 				context (req, (event, data, id, retry) => {
 					var message = new StringBuilder ();
@@ -124,6 +124,8 @@ namespace Valum.ServerSentEvents {
 			} catch (Error err) {
 				warning (err.message);
 			}
+
+			return true;
 		};
 	}
 }

--- a/src/valum/valum-subdomain.vala
+++ b/src/valum/valum-subdomain.vala
@@ -78,18 +78,18 @@ namespace Valum {
 			var expected_labels = expected_subdomain.split (".");
 			var labels          = extract_subdomains (req.uri.host, skip);
 			if (expected_labels.length > labels.length) {
-				next (req, res); return;
+				return next (req, res);
 			}
 			if (SubdomainFlags.STRICT in flags && expected_labels.length != labels.length) {
-				next (req, res); return;
+				return next (req, res);
 			}
 			for (var i = 1; i <= expected_labels.length; i++) {
 				if (expected_labels[expected_labels.length - i] != "*" &&
 					expected_labels[expected_labels.length - i] != labels[labels.length - i]) {
-					next (req, res); return;
+					return next (req, res);
 				}
 			}
-			forward (req, res, next, stack);
+			return forward (req, res, next, stack);
 		};
 	}
 }

--- a/src/valum/valum.vala
+++ b/src/valum/valum.vala
@@ -64,7 +64,7 @@ namespace Valum {
 	 *                preceeding 'next' invocation or initialized by the
 	 *                first {@link Valum.MatcherCallback}
 	 */
-	public delegate void HandlerCallback (Request req,
+	public delegate bool HandlerCallback (Request req,
 	                                      Response res,
 	                                      NextCallback next,
 	                                      Context context) throws Informational,
@@ -92,7 +92,7 @@ namespace Valum {
 	 * @param req request for the next handler
 	 * @param res response for the next handler
 	 */
-	public delegate void NextCallback (Request req, Response res) throws Informational,
+	public delegate bool NextCallback (Request req, Response res) throws Informational,
 	                                                                     Success,
 	                                                                     Redirection,
 	                                                                     ClientError,

--- a/src/vsgi/vsgi-server.vala
+++ b/src/vsgi/vsgi-server.vala
@@ -70,10 +70,13 @@ namespace VSGI {
 		 * The application must call {@link Response.write_head} at some point.
 		 *
 		 * Once dispatched, the {@link Response.head_written} property is
-		 * expected to be true unless its reference still held somewhere else.
+		 * expected to be true unless its reference still held somewhere else
+		 * and the return value is 'true'.
+		 *
+		 * @return true if the request and response were dispatched
 		 */
-		protected void dispatch (Request req, Response res) ensures (res.ref_count > 1 || res.head_written) {
-			_application (req, res);
+		protected bool dispatch (Request req, Response res) ensures (result && res.ref_count > 1 || res.head_written) {
+			return _application (req, res);
 		}
 	}
 }

--- a/src/vsgi/vsgi.vala
+++ b/src/vsgi/vsgi.vala
@@ -40,6 +40,7 @@ namespace VSGI {
 	 *
 	 * @param req a resource being requested
 	 * @param res the response to that request
+	 * @return true if the request was or will eventually be fully handled
 	 */
-	public delegate void ApplicationCallback (Request req, Response res);
+	public delegate bool ApplicationCallback (Request req, Response res);
 }

--- a/tests/negociate-test.vala
+++ b/tests/negociate-test.vala
@@ -10,17 +10,17 @@ public void test_negociate () {
 
 	req.headers.append ("Accept", "text/html; q=0.9, text/xml; q=0");
 
-	negociate ("Accept", "text/html", () => {}) (req, res, () => {
+	negociate ("Accept", "text/html", () => { return true; }) (req, res, () => {
 		assert_not_reached ();
 	}, new Context ());
 
 	negociate ("Accept", "text/xml", () => {
 		assert_not_reached ();
-	}) (req, res, () => {}, new Context ());
+	}) (req, res, () => { return true; }, new Context ());
 
 	negociate ("Accept-Encoding", "utf-8", () => {
 		assert_not_reached ();
-	}) (req, res, () => {}, new Context ());
+	}) (req, res, () => { return true; }, new Context ());
 }
 
 

--- a/tests/route-test.vala
+++ b/tests/route-test.vala
@@ -22,7 +22,7 @@ using VSGI.Mock;
  * @since 0.1
  */
 public void test_route () {
-	var route   = new MatcherRoute (Method.GET, (req) => { return true; }, (req, res) => {});
+	var route   = new MatcherRoute (Method.GET, (req) => { return true; }, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 	var context = new Context ();
 
@@ -33,7 +33,7 @@ public void test_route () {
  * @since 0.1
  */
 public void test_route_from_rule () {
-	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
+	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => { return true; });
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 	var context = new Context ();
 
@@ -49,7 +49,7 @@ public void test_route_from_rule () {
  * @since 0.1
  */
 public void test_route_from_rule_without_captures () {
-	var route   = new RuleRoute (Method.GET, "/", null, (req, res) => {});
+	var route   = new RuleRoute (Method.GET, "/", null, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var context = new Context ();
 
@@ -65,7 +65,7 @@ public void test_route_from_rule_without_captures () {
 public void test_route_from_rule_undefined_type () {
 	try {
 		var route  = new RuleRoute (Method.GET, "/<uint:unknown_type>", new HashTable<string, Regex> (str_hash,
-					str_equal), (req, res) => {});
+					str_equal), (req, res) => { return true; });
 	} catch (RegexError err) {
 		return;
 	}
@@ -76,7 +76,7 @@ public void test_route_from_rule_undefined_type () {
  * @since 0.1
  */
 public void test_route_from_regex () {
-	var route   = new RegexRoute (Method.GET, /\/(?<id>\d+)/, (req, res) => {});
+	var route   = new RegexRoute (Method.GET, /\/(?<id>\d+)/, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 	var context = new Context ();
 
@@ -92,7 +92,7 @@ public void test_route_from_regex () {
  * @since 0.2
  */
 public void test_route_from_regex_multiple_captures () {
-	var route   = new RegexRoute (Method.GET, /\/(?<action>\w+)\/(?<id>\d+)/, (req, res) => {});
+	var route   = new RegexRoute (Method.GET, /\/(?<action>\w+)\/(?<id>\d+)/, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/user/5"));
 	var context = new Context ();
 
@@ -109,7 +109,7 @@ public void test_route_from_regex_multiple_captures () {
  * @since 0.1
  */
 public void test_route_from_regex_without_captures () {
-	var route   = new RegexRoute (Method.GET, /\/.*/, (req, res) => {});
+	var route   = new RegexRoute (Method.GET, /\/.*/, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var context = new Context ();
 
@@ -123,7 +123,7 @@ public void test_route_from_regex_without_captures () {
  * @since 0.1
  */
 public void test_route_match () {
-	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {});
+	var route   = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/5"));
 	var context = new Context ();
 
@@ -140,7 +140,7 @@ public void test_route_match () {
 public void test_route_match_not_matching () {
 	var types   = new HashTable<string, Regex> (str_hash, str_equal);
 	types["int"] = /\d+/;
-	var route   = new RuleRoute (Method.GET, "/<int:id>", types, (req, res) => {});
+	var route   = new RuleRoute (Method.GET, "/<int:id>", types, (req, res) => { return true; });
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
 	var context = new Context ();
 
@@ -155,6 +155,7 @@ public void test_route_fire () {
 	var setted = false;
 	var route = new RuleRoute (Method.GET, "/<int:id>", null, (req, res) => {
 		setted = true;
+		return true;
 	});
 
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/home"));
@@ -163,7 +164,7 @@ public void test_route_fire () {
 
 	assert (setted == false);
 
-	route.fire (req, res, () => {}, null);
+	route.fire (req, res, () => { return true; }, null);
 
 	assert (setted);
 }

--- a/tests/router-test.vala
+++ b/tests/router-test.vala
@@ -25,9 +25,9 @@ public static void test_router () {
 	var router = new Router ();
 
 	try {
-		router.get ("<int:i>", (req, res) => {});
-		router.get ("<string:i>", (req, res) => {});
-		router.get ("<path:i>", (req, res) => {});
+		router.get ("<int:i>", (req, res) => { return true; });
+		router.get ("<string:i>", (req, res) => { return true; });
+		router.get ("<path:i>", (req, res) => { return true; });
 	} catch (RegexError err) {
 		assert_not_reached ();
 	}
@@ -41,6 +41,7 @@ public static void test_router_handle () {
 
 	router.get ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -61,6 +62,7 @@ public static void test_router_get () {
 
 	router.get ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -79,6 +81,7 @@ public void test_router_get_default_head () {
 
 	router.get ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method ("HEAD", new Soup.URI ("http://localhost/"));
@@ -97,6 +100,7 @@ public void test_router_only_get () {
 
 	router.rule (Method.ONLY_GET, "", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method ("GET", new Soup.URI ("http://localhost/"));
@@ -115,6 +119,7 @@ public static void test_router_post () {
 
 	router.post ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method ("POST", new Soup.URI ("http://localhost/"));
@@ -133,6 +138,7 @@ public static void test_router_put () {
 
 	router.put ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.PUT, new Soup.URI ("http://localhost/"));
@@ -151,6 +157,7 @@ public static void test_router_delete () {
 
 	router.delete ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.DELETE, new Soup.URI ("http://localhost/"));
@@ -169,6 +176,7 @@ public static void test_router_head () {
 
 	router.head ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.HEAD, new Soup.URI ("http://localhost/"));
@@ -187,6 +195,7 @@ public static void test_router_options () {
 
 	router.options ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.OPTIONS, new Soup.URI ("http://localhost/"));
@@ -205,6 +214,7 @@ public static void test_router_trace () {
 
 	router.trace ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.TRACE, new Soup.URI ("http://localhost/"));
@@ -223,6 +233,7 @@ public static void test_router_connect () {
 
 	router.connect ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.CONNECT, new Soup.URI ("http://localhost/"));
@@ -240,6 +251,7 @@ public static void test_router_patch () {
 
 	router.patch ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_method (VSGI.Request.PATCH, new Soup.URI ("http://localhost/"));
@@ -258,6 +270,7 @@ public void test_router_rule_wildcard () {
 
 	router.get ("*", (req, res, next, context) => {
 		res.status = 418;
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/5"));
@@ -276,6 +289,7 @@ public void test_router_rule_wildcard_matches_empty_path () {
 
 	router.get ("*", (req, res, next, context) => {
 		res.status = 418;
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -314,6 +328,7 @@ public void test_router_rule_any () {
 
 	router.get ("*", (req, res, next, context) => {
 		res.status = 418;
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/5"));
@@ -330,6 +345,7 @@ public static void test_router_regex () {
 
 	var route = router.regex (Method.GET, /home/, (req, res) => {
 		res.status = 418;
+		return true;
 	}) as RegexRoute;
 
 	assert ("^/home$" == route.regex.get_pattern ());
@@ -351,6 +367,7 @@ public static void test_router_matcher () {
 
 	router.matcher (Method.GET, (req) => { return req.uri.get_path () == "/"; }, (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request  = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -370,6 +387,7 @@ public static void test_router_scope () {
 	router.scope ("test", (inner) => {
 		inner.get ("test", (req, res) => {
 			res.status = 418; // I'm a teapot
+			return true;
 		});
 	});
 
@@ -389,7 +407,7 @@ public void test_router_scope_regex () {
 
 	Route? route = null;
 	router.scope ("test", (test) => {
-		route = test.regex (Method.GET, /(?<id>\d+)/, (req, res) => {});
+		route = test.regex (Method.GET, /(?<id>\d+)/, (req, res) => { return true; });
 	});
 
 	var req     = new Request.with_uri (new Soup.URI ("http://localhost/test/5"));
@@ -486,7 +504,7 @@ public static void test_router_client_error_method_not_allowed () {
 	var router = new Router ();
 
 	router.post ("", (req, res) => {
-
+		return true;
 	});
 
 	router.use ((req, res) => {
@@ -558,6 +576,7 @@ public static void test_router_custom_method () {
 
 	router.rule (Method.OTHER, "", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request = new Request.with_method ("TEST", new Soup.URI ("http://localhost/"));
@@ -575,11 +594,11 @@ public static void test_router_method_not_allowed () {
 	var router = new Router ();
 
 	router.get ("", (req, res) => {
-
+		return true;
 	});
 
 	router.put ("", (req, res) => {
-
+		return true;
 	});
 
 	var request = new Request.with_method ("POST", new Soup.URI ("http://localhost/"));
@@ -604,12 +623,12 @@ public static void test_router_method_not_allowed_excludes_request_method () {
 
 	// matching, but not the same HTTP method
 	router.matcher (Method.GET, () => { get_matched++; return true; }, (req, res) => {
-
+		return true;
 	});
 
 	// not matching, but same HTTP method
 	router.matcher (Method.POST, () => { post_matched++; return false; }, (req, res) => {
-
+		return true;
 	});
 
 	var request = new Request.with_method ("POST", new Soup.URI ("http://localhost/"));
@@ -647,6 +666,7 @@ public static void test_router_subrouting () {
 
 	subrouter.get ("", (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	router.get ("", subrouter.handle);
@@ -666,16 +686,17 @@ public static void test_router_next () {
 	var router = new Router ();
 
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	// should recurse a bit in process_routing
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next) => {
 		res.status = 418;
+		return true;
 	});
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -690,12 +711,12 @@ public static void test_router_next_not_found () {
 	var router = new Router ();
 
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	// should recurse a bit in process_routing
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	// no more route matching
@@ -715,11 +736,11 @@ public static void test_router_next_propagate_error () {
 	var router = new Router ();
 
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next) => {
@@ -743,16 +764,17 @@ public static void test_router_next_propagate_state () {
 
 	router.get ("", (req, res, next, context) => {
 		context["state"] = state;
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next) => {
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next, context) => {
 		res.status = 413;
 		assert (state == context["state"]);
+		return true;
 	});
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -772,13 +794,13 @@ public static void test_router_next_replace_propagated_state () {
 
 	router.get ("", (req, res, next, context) => {
 		context["state"] = state;
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next, context) => {
 		assert (state == context["state"]);
 		context["state"] = "something really different";
-		next (req, res);
+		return next (req, res);
 	});
 
 	router.get ("", (req, res, next, context) => {
@@ -786,6 +808,7 @@ public static void test_router_next_replace_propagated_state () {
 		assert (context["state"].holds (typeof (string)));
 		assert (context.parent["state"].holds (typeof (string)));
 		assert (context.parent.parent["state"].holds (typeof (Object)));
+		return true;
 	});
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -803,6 +826,7 @@ public static void test_router_status_propagates_error_message () {
 		var message = context["message"];
 		res.status = 418;
 		assert ("The request URI / was not found." == message.get_string ());
+		return true;
 	});
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -825,6 +849,7 @@ public void test_router_status_handle_error () {
 
 	router.status (500, (req, res) => {
 		res.status = 418;
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -842,7 +867,7 @@ public static void test_router_invoke () {
 	var router = new Router ();
 
 	router.get ("", (req, res, next) => {
-		router.invoke (req, res, next);
+		return router.invoke (req, res, next);
 	});
 
 	router.get ("", (req, res) => {
@@ -866,7 +891,7 @@ public static void test_router_invoke_propagate_state () {
 
 	router.get ("", (req, res, next, context) => {
 		context["message"] = message;
-		router.invoke (req, res, next);
+		return router.invoke (req, res, next);
 	});
 
 	router.get ("", (req, res, next, context) => {
@@ -893,10 +918,11 @@ public void test_router_then () {
 
 	router.get ("<int:id>", (req, res, next) => {
 		setted = true;
-		next (req, res);
+		return next (req, res);
 	}).then ((req, res) => {
 		assert (setted);
 		then_setted = true;
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/5"));
@@ -918,11 +944,12 @@ public void test_router_then_preserve_matching_context () {
 
 	router.get ("<int:id>", (req, res, next, context) => {
 		context["test"] = "test";
-		next (req, res);
+		return next (req, res);
 	}).then ((req, res, next, context) => {
 		reached = true;
 		assert ("test" == context["test"].get_string ());
 		assert ("5" == context["id"].get_string ());
+		return true;
 	});
 
 	var req = new Request.with_uri (new Soup.URI ("http://localhost/5"));

--- a/tests/subdomain-test.vala
+++ b/tests/subdomain-test.vala
@@ -28,7 +28,7 @@ public void test_subdomain () {
 
 	subdomain ("api", () => {
 		assert_not_reached ();
-	}, SubdomainFlags.NONE) (req, res, () => {}, new Context ());
+	}, SubdomainFlags.NONE) (req, res, () => { return true; }, new Context ());
 }
 
 /**
@@ -39,7 +39,7 @@ public void test_subdomain_joker () {
 		var req   = new Request.with_uri (new Soup.URI ("http://api.example.com/"));
 		var res   = new Response (req);
 
-		subdomain("*", () => {}) (req, res, () => {
+		subdomain("*", () => { return true; }) (req, res, () => {
 			assert_not_reached ();
 		}, new Context ());
 	}
@@ -50,7 +50,7 @@ public void test_subdomain_joker () {
 
 		subdomain("*", () => {
 			assert_not_reached ();
-		}) (req, res, () => {}, new Context ());
+		}) (req, res, () => { return true; }, new Context ());
 	}
 }
 
@@ -61,10 +61,10 @@ public void test_subdomain_strict () {
 	var req   = new Request.with_uri (new Soup.URI ("http://dev.api.example.com/"));
 	var res   = new Response (req);
 
-	subdomain ("api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
-	subdomain ("dev.api", () => {}) (req, res, () => { assert_not_reached (); }, new Context ());
-	subdomain ("api", () => { assert_not_reached (); }, SubdomainFlags.STRICT) (req, res, () => {}, new Context ());
-	subdomain ("dev.api.example.com", () => {}, SubdomainFlags.STRICT, 0) (req, res, () => { assert_not_reached (); }, new Context ());
+	subdomain ("api", () => { return true; }) (req, res, () => { assert_not_reached (); }, new Context ());
+	subdomain ("dev.api", () => { return true; }) (req, res, () => { assert_not_reached (); }, new Context ());
+	subdomain ("api", () => { assert_not_reached (); }, SubdomainFlags.STRICT) (req, res, () => { return true; }, new Context ());
+	subdomain ("dev.api.example.com", () => { return true; }, SubdomainFlags.STRICT, 0) (req, res, () => { assert_not_reached (); }, new Context ());
 }
 
 /**


### PR DESCRIPTION
As described in #165 

Introducing this feature has many advantages:

 - return `next` directly
 - try `next` and do something else if it's being ignored
 - let the server know if the request has been ignored

However, it's a pretty aggressive API break.

- [ ] handle ignored requests (see what servers can do about it)
- [x] update the documentation (especially the code examples)
- [x] obtain positive feedback from @Bob131 