### PR TITLE
Provide expansion utilities to write the response body

### DIFF
--- a/docs/application.rst
+++ b/docs/application.rst
@@ -39,7 +39,7 @@ a :doc:`route` instance.
 ::
 
     app.get ("", (req, res, next, context) => {
-        res.body.write_all ("Hello world!".data, null);
+        res.expand_utf8 ("Hello world!", null);
     });
 
 Every route declaration has a callback associated that does the request
@@ -77,7 +77,7 @@ a :doc:`vsgi/request` and :doc:`vsgi/response`.
 
     new Server ("org.valum.example.App", (req, res) => {
         res.status = 200;
-        res.body.write_all ("Hello world!".data, null);
+        res.expand ("Hello world!", null);
     }).run ({"app", "--port", "3003"});
 
 Usually, you would only pass the CLI arguments to ``run``, so that your runtime

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -33,7 +33,7 @@ the latest changes in the framework.
     var app = new Router ();
 
     app.get ("", (req, res) => {
-        res.body.write_all ("Hello world!".data, null);
+        res.expand ("Hello world!".data, null);
     });
 
     new Server (app.handle).run ({"app", "--port", "3003"});

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -52,7 +52,7 @@ spending time on producing a body that won't be considered is important.
         return;
     }
 
-    res.body.write_all ("<!DOCTYPE html><html></html>");
+    res.expand_utf8 ("<!DOCTYPE html><html></html>");
 
 Use the ``construct`` block to perform post-initialization work. It will be
 called independently of how the object is constructed.

--- a/docs/recipes/persistence.rst
+++ b/docs/recipes/persistence.rst
@@ -42,7 +42,7 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
         Memcached.ReturnCode error;
         var value = memcached.get ("hello", out flags, out error);
 
-        res.body.write_all (value, null);
+        res.expand (value, null);
     });
 
     app.post ("<key>", (req, res) => {
@@ -56,5 +56,5 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
         Memcached.ReturnCode error;
         var value = memcached.get ("hello", out flags, out error);
 
-        res.body.write_all (value, null);
+        res.expand (value, null);
     });

--- a/docs/recipes/scripting.rst
+++ b/docs/recipes/scripting.rst
@@ -34,10 +34,10 @@ Lua
     // GET /lua
     app.get ("lua", (req, res) => {
         // evaluate a string containing Lua code
-        res.body.write_all (some_lua_code.data, null);
+        res.expand_utf8 (some_lua_code, null);
 
         // evaluate a file containing Lua code
-        res.body.write_all (lua.do_file ("scripts/hello.lua").data, null);
+        res.expand_utf8 (lua.do_file ("scripts/hello.lua"), null);
     });
 
     new Server ("org.valum.example.Lua", app.handle).run ();

--- a/docs/router.rst
+++ b/docs/router.rst
@@ -166,7 +166,7 @@ invoked to jump to the next status handler in the queue.
 
     app.status (Soup.Status.NOT_FOUND, (req, res) => {
         res.status = 404;
-        res.body.write_all ("Not found!".data, null);
+        res.expand_utf8 ("Not found!", null);
     });
 
 :doc:`redirection-and-error` can be thrown during the status handling, they
@@ -205,7 +205,7 @@ It provides a nice way to ignore passively unrecoverable errors.
 ::
 
     app.get ("", (req, res) => {
-        res.write_all_async ("Hello world!".data, null, () => {
+        res.expand_utf8_async ("Hello world!", null, () => {
             app.invoke (req, res, () => {
                 throw new IOError.FAILED ("I/O failed undesirably.")
             });
@@ -367,7 +367,7 @@ with custom and default status code handlers. It constitute an entry point for
 ::
 
     app.get ("", (req, res, next) => {
-        res.body.write_all_async ("Hello world!".data, Priority.DEFAULT, null, () => {
+        res.expand_utf8_async ("Hello world!", Priority.DEFAULT, null, () => {
             app.invoke (req, res, next);
         });
     });
@@ -401,7 +401,7 @@ responses designed for non-human client.
     });
 
     app.status (Status.NOT_ACCEPTABLE, (req, res, next, context) => {
-        res.body.write_all ("<p>%s</p>".printf (context["message"].get_string ()).data, null);
+        res.expand_utf8 ("<p>%s</p>".printf (context["message"].get_string ()), null);
     });
 
 Middleware
@@ -472,7 +472,7 @@ the :doc:`vsgi/response` body.
     });
 
     app.get ("home", (req, res) => {
-        res.body.write_all ("Hello world!".data, null); // transparently compress the output
+        res.expand_utf8 ("Hello world!", null); // transparently compress the output
     });
 
 If this is wrapped in a function, which is typically the case, it can even be
@@ -488,7 +488,7 @@ used directly from the handler.
     app.get ("home", compress);
 
     app.get ("home", (req, res) => {
-        res.body.write_all ("Hello world!".data, null);
+        res.expand_utf8 ("Hello world!", null);
     });
 
 Alternatively, a handling middleware can be used directly instead of being
@@ -498,6 +498,6 @@ attached to a :doc:`route`, the processing will happen in a ``NextCallback``.
 
     app.get ("home", (req, res, next, context) => {
         compress (req, res, (req, res) => {
-            res.body.write_all ("Hello world!".data, null);
+            res.expand_utf8 ("Hello world!", null);
         }, new Context.with_parent (context));
     });

--- a/docs/vsgi/converters.rst
+++ b/docs/vsgi/converters.rst
@@ -30,7 +30,7 @@ A typical utilisation would be to negociate a ``Content-Encoding: zlib`` header.
         // the body will be compressed transparently
         res.body = new ConverterOutputStream (res.body, new ZLibCompressor ());
 
-        res.body.write_all ("Hello world!".data, null);
+        res.expand_utf8 ("Hello world!", null);
     });
 
 ChunkedConverter

--- a/docs/vsgi/filters.rst
+++ b/docs/vsgi/filters.rst
@@ -27,6 +27,6 @@ You can use any :doc:`converters` provided by GLib or VSGI with ease.
         res = new ConvertedResponse (res, new ZlibCompressor (ZlibCompressorFormat.GZIP));
         res.status = 200;
         res.headers.append ("Content-Encoding", "gzip");
-        res.body.write_all ("Hello world!".data);
+        res.expand_utf8 ("Hello world!");
     });
 

--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -25,7 +25,7 @@ Additionally, an array of supported HTTP methods is provided by
 ::
 
     if (req.method == Request.GET) {
-        res.body.write_all ("Hello world!".data, null);
+        res.expand_utf8 ("Hello world!", null);
     }
 
     if (req.method == Request.POST) {

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -72,6 +72,24 @@ The body of a response is accessed through the ``body`` property. It inherits
 from `GLib.OutputStream`_ and provides synchronous and asynchronous streaming
 capabilities.
 
+Fixed-size body
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.3
+
+To deal with fixed-size body, ``expand``, ``expand_utf8`` utilities as well as
+their respective asynchronous versions are provided.
+
+It will automatically set the ``Content-Length`` header to the size of the
+provided buffer, write the response head and pipe the buffer into the body
+stream.
+
+::
+
+    app.get ("", (req, res) => {
+        res.expand_utf8 ("Hello world!");
+    })
+
 Filtering
 ~~~~~~~~~
 

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -82,7 +82,7 @@ their respective asynchronous versions are provided.
 
 It will automatically set the ``Content-Length`` header to the size of the
 provided buffer, write the response head and pipe the buffer into the body
-stream.
+stream and close it properly.
 
 ::
 

--- a/examples/api-interaction/app.vala
+++ b/examples/api-interaction/app.vala
@@ -39,7 +39,7 @@ app.get ("", (req, res) => {
 
 			var main = parser.get_root ().get_object ().get_object_member ("main");
 
-			res.body.write_all ("""
+			res.expand_utf8 ("""
 			<h1>Weather in Montreal</h1>
 			<dl>
 			  <dt>Humidity</dt><dd>%s</dd>
@@ -52,7 +52,7 @@ app.get ("", (req, res) => {
 			            main.get_string_member ("pressure"),
 			            main.get_string_member ("temp"),
 			            main.get_string_member ("temp_max"),
-						main.get_string_member ("temp_min")).data, null);
+						main.get_string_member ("temp_min")), null);
 		});
 	});
 });

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -67,27 +67,27 @@ app.get ("headers", (req, res) => {
 	req.headers.foreach ((name, header) => {
 		headers.append_printf ("%s: %s\n", name, header);
 	});
-	res.body.write_all (headers.data, null);
+	res.expand_utf8 (headers.str, null);
 });
 
 app.get ("query", (req, res) => {
 	if (req.query == null) {
-		res.body.write_all ("null".data, null);
+		res.expand_utf8 ("null", null);
 	} else {
 		var query = new StringBuilder ();
 		req.query.foreach ((k, v) => {
 			query.append_printf ("%s: %s\n", k, v);
 		});
-		res.body.write_all (query.data, null);
+		res.expand_utf8 (query.str, null);
 	}
 });
 
 app.get ("cookies", (req, res) => {
 	if (req.cookies == null) {
-		res.body.write_all ("null".data, null);
+		res.expand_utf8 ("null", null);
 	} else {
 		foreach (var cookie in req.cookies) {
-			res.body.write_all ("%s: %s\n".printf (cookie.name, cookie.value).data, null);
+			res.expand_utf8 ("%s: %s\n".printf (cookie.name, cookie.value), null);
 		}
 	}
 });
@@ -96,7 +96,7 @@ app.scope ("cookie", (inner) => {
 	inner.get ("<name>", (req, res, next, context) => {
 		foreach (var cookie in req.cookies)
 			if (cookie.name == context["name"].get_string ())
-				res.body.write_all ("%s\n".printf (cookie.value).data, null);
+				res.expand_utf8 ("%s\n".printf (cookie.value), null);
 	});
 
 	inner.post ("<name>", (req, res, next, context) => {
@@ -108,7 +108,7 @@ app.scope ("cookie", (inner) => {
 app.scope ("urlencoded-data", (inner) => {
 	inner.get ("", (req, res) => {
 		res.headers.set_content_type ("text/html", null);
-		res.body.write_all (
+		res.expand_utf8 (
 		"""
 		<!DOCTYPE html>
 		<html>
@@ -119,7 +119,7 @@ app.scope ("urlencoded-data", (inner) => {
 			</form>
 		  </body>
 		</html>
-		""".data, null);
+		""", null);
 	});
 
 	inner.post ("", (req, res) => {
@@ -130,29 +130,29 @@ app.scope ("urlencoded-data", (inner) => {
 			builder.append_printf ("%s: %s\n", k, v);
 		});
 
-		res.body.write_all (builder.str.data, null);
+		res.expand_utf8 (builder.str, null);
 	});
 });
 
 // hello world! (compare with Node.js!)
 app.get ("hello", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	res.expand_utf8 ("Hello world!", null);
 });
 
 app.get ("hello/", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	res.expand_utf8 ("Hello world!", null);
 });
 
 app.rule (Method.GET | Method.POST, "get-and-post", (req, res) => {
-	res.body.write_all ("Matches GET and POST".data, null);
+	res.expand_utf8 ("Matches GET and POST", null);
 });
 
 app.rule (Method.GET, "custom-method", (req, res) => {
-	res.body.write_all (req.method.data, null);
+	res.expand_utf8 (req.method, null);
 });
 
 app.get ("hello/<id>", (req, res, next, context) => {
-	res.body.write_all ("hello %s!".printf (context["id"].get_string ()).data, null);
+	res.expand_utf8 ("hello %s!".printf (context["id"].get_string ()), null);
 });
 
 app.get ("users/<int:id>(/<action>)?", (req, res, next, context) => {
@@ -167,23 +167,23 @@ app.get ("users/<int:id>(/<action>)?", (req, res, next, context) => {
 app.register_type ("permutations", /abc|acb|bac|bca|cab|cba/);
 
 app.get ("custom-route-type/<permutations:p>", (req, res, next, context) => {
-	res.body.write_all (context["p"].get_string ().data, null);
+	res.expand_utf8 (context["p"].get_string (), null);
 });
 
 app.get ("trailing-slash/?", (req, res) => {
 	if (req.uri.get_path ().has_suffix ("/")) {
-		res.body.write_all ("It has it!".data, null);
+		res.expand_utf8 ("It has it!", null);
 	} else {
-		res.body.write_all ("It does not!".data, null);
+		res.expand_utf8 ("It does not!", null);
 	}
 });
 
 app.regex (Method.GET, /custom-regular-expression/, (req, res) => {
-	res.body.write_all ("This route was matched using a custom regular expression.".data, null);
+	res.expand_utf8 ("This route was matched using a custom regular expression.", null);
 });
 
 app.matcher (Method.GET, (req) => { return req.uri.get_path () == "/custom-matcher"; }, (req, res) => {
-	res.body.write_all ("This route was matched using a custom matcher.".data, null);
+	res.expand_utf8 ("This route was matched using a custom matcher.", null);
 });
 
 // scoped routing
@@ -193,11 +193,11 @@ app.scope ("admin", (adm) => {
 		// matches /admin/fun/hack
 		fun.get ("hack", (req, res) => {
 			var time = new DateTime.now_utc ();
-			res.body.write_all ("It's %s around here!\n".printf (time.format ("%H:%M")).data, null);
+			res.expand_utf8 ("It's %s around here!\n".printf (time.format ("%H:%M")), null);
 		});
 		// matches /admin/fun/heck
 		fun.get ("heck", (req, res) => {
-			res.body.write_all ("Wuzzup!".data, null);
+			res.expand_utf8 ("Wuzzup!", null);
 		});
 	});
 });
@@ -216,7 +216,7 @@ app.use (subdomain ("api", api.handle));
 
 api.get ("repository/<name>", (req, res, next, context) => {
 	var name = context["name"].get_string ();
-	res.body.write_all (name.data, null);
+	res.expand_utf8 (name, null);
 });
 
 // delegate all other GET requests to a subrouter
@@ -227,7 +227,7 @@ app.get ("next", (req, res, next) => {
 });
 
 app.get ("next", (req, res) => {
-	res.body.write_all ("Matched by the next route in the queue.".data, null);
+	res.expand_utf8 ("Matched by the next route in the queue.", null);
 });
 
 app.get ("state", (req, res, next, context) => {
@@ -236,7 +236,7 @@ app.get ("state", (req, res, next, context) => {
 });
 
 app.get ("state", (req, res, next, context) => {
-	res.body.write_all (context["state"].get_string ().data, null);
+	res.expand_utf8 (context["state"].get_string (), null);
 });
 
 // Ctpl template rendering
@@ -304,13 +304,13 @@ app.get ("server-sent-events", stream_events ((req, send) => {
 
 app.get ("negociate", accept ("application/json", (req, res) => {
 	res.headers.set_content_type ("application/json", null);
-	res.body.write_all ("{\"a\":\"b\"}".data, null);
+	res.expand_utf8 ("{\"a\":\"b\"}", null);
 })).then (accept ("text/xml", (req, res) => {
 	res.headers.set_content_type ("text/xml", null);
-	res.body.write_all ("<a>b</a>".data, null);
+	res.expand_utf8 ("<a>b</a>", null);
 })).then ((req, res) => {
 	res.status = global::Soup.Status.NOT_ACCEPTABLE;
-	res.body.write_all ("Supply the 'Accept' header with either 'application/json' or 'text/xml'.".data, null);
+	res.expand_utf8 ("Supply the 'Accept' header with either 'application/json' or 'text/xml'.", null);
 });
 
 app.status (Soup.Status.NOT_FOUND, (req, res, next, context) => {

--- a/examples/cgi/app.vala
+++ b/examples/cgi/app.vala
@@ -21,7 +21,7 @@ using VSGI.CGI;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	res.expand_utf8 ("Hello world!", null);
 });
 
 new Server ("org.valum.example.CGI", app.handle).run ();

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -23,7 +23,7 @@ public static int main (string[] args) {
 
 	// default route
 	app.get ("", (req, res) => {
-		res.body.write_all ("Hello world!".data, null);
+		res.expand_utf8 ("Hello world!", null);
 	});
 
 	app.get ("random/<int:size>", (req, res, next, context) => {

--- a/examples/lua/app.vala
+++ b/examples/lua/app.vala
@@ -29,7 +29,7 @@ app.get ("", (req, res) => {
 		require "markdown"
 		return markdown('## Hello from lua.eval!')""");
 
-	res.body.write_all (vm.to_string (-1).data, null);
+	res.expand_utf8 (vm.to_string (-1), null);
 });
 
 new Server ("org.valum.example.Lua", app.handle).run ({"app", "--all"});

--- a/examples/markdown/app.vala
+++ b/examples/markdown/app.vala
@@ -9,7 +9,7 @@ app.get ("", (req, res) => {
 	doc.compile (DocumentFlags.EMBED);
 	string markdown;
 	doc.document (out markdown);
-	res.body.write_all (markdown.data, null);
+	res.expand_utf8 (markdown, null);
 });
 
 new Server ("org.valum.example.Markdown", app.handle).run ();

--- a/examples/memcached/app.vala
+++ b/examples/memcached/app.vala
@@ -30,7 +30,7 @@ app.get ("<key>", (req, res, next, context) => {
 
 	switch (error) {
 		case Memcached.ReturnCode.SUCCESS:
-			res.body.write_all (data, null);
+			res.expand (data, null);
 			break;
 		case Memcached.ReturnCode.NOTFOUND:
 			throw new ClientError.NOT_FOUND ("key '%s' was not found", key);

--- a/examples/modular-app/admin-router.vala
+++ b/examples/modular-app/admin-router.vala
@@ -48,7 +48,7 @@ public class AdminRouter : Router {
 		}
 
 		res.headers.set_content_type ("text/html", null);
-		res.body.write_all ("""
+		res.expand_utf8 ("""
 		<!DOCTYPE html>
 		<html>
 		  <head>
@@ -61,7 +61,7 @@ public class AdminRouter : Router {
 		    </form>
 		  </body>
 		</html>
-		""".data, null);
+		""", null);
 	}
 
 	/**
@@ -69,6 +69,6 @@ public class AdminRouter : Router {
 	 */
 	public void view (Request req, Response res, NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
-		res.body.write ("Hello admin!".data, null);
+		res.expand_utf8 ("Hello admin!", null);
 	}
 }

--- a/examples/modular-app/app.vala
+++ b/examples/modular-app/app.vala
@@ -21,7 +21,7 @@ using VSGI.HTTP;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all (
+	res.expand_utf8 (
 	"""
 	<!DOCTYPE html>
 	<html>
@@ -30,7 +30,7 @@ app.get ("", (req, res) => {
 	<a href="/admin/view">Enter administrative business</a>
 	</body>
 	</html>
-	""".data, null);
+	""", null);
 });
 
 app.rule (Method.ANY, "user/*", new UserRouter ().handle);

--- a/examples/modular-app/user-router.vala
+++ b/examples/modular-app/user-router.vala
@@ -26,6 +26,6 @@ public class UserRouter : Router {
 
 	public void view (Request req, Response res, NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
-		res.body.write_all ("Hello, user %s!".printf (ctx["id"].get_string ()).data, null);
+		res.expand_utf8 ("Hello, user %s!".printf (ctx["id"].get_string ()), null);
 	}
 }

--- a/examples/scgi/app.vala
+++ b/examples/scgi/app.vala
@@ -21,7 +21,7 @@ using VSGI.SCGI;
 var app = new Router ();
 
 app.get ("", (req, res) => {
-	res.body.write_all ("Hello world!".data, null);
+	res.expand_utf8 ("Hello world!", null);
 });
 
 app.post ("", (req, res) => {
@@ -29,7 +29,7 @@ app.post ("", (req, res) => {
 });
 
 app.get ("async", (req, res) => {
-	res.body.write_all_async.begin ("Hello world!".data, Priority.DEFAULT, null);
+	res.expand_utf8_async.begin ("Hello world!", Priority.DEFAULT, null);
 });
 
 new Server ("org.valum.example.SCGI", app.handle).run ({"app"});

--- a/src/vsgi/vsgi-response.vala
+++ b/src/vsgi/vsgi-response.vala
@@ -245,7 +245,8 @@ namespace VSGI {
 			headers.set_content_length (buffer.length);
 			size_t bytes_written;
 			return write_head (out bytes_written, cancellable) &&
-			       body.write_all (buffer, out bytes_written, cancellable);
+			       body.write_all (buffer, out bytes_written, cancellable) &&
+			       body.close (cancellable);
 		}
 
 		/**
@@ -262,12 +263,13 @@ namespace VSGI {
 		 * @since 0.3
 		 */
 		public async bool expand_async (uint8[]      buffer,
-		                          int          priority    = GLib.Priority.DEFAULT,
-		                          Cancellable? cancellable = null) throws Error {
+		                                int          priority    = GLib.Priority.DEFAULT,
+		                                Cancellable? cancellable = null) throws Error {
 			headers.set_content_length (buffer.length);
 			size_t bytes_written;
 			return (yield write_head_async (priority, cancellable, out bytes_written)) &&
-			       (yield body.write_all_async (buffer, priority, cancellable, out bytes_written));
+			       (yield body.write_all_async (buffer, priority, cancellable, out bytes_written)) &&
+			       (yield body.close_async (priority, cancellable));
 		}
 
 		/**

--- a/src/vsgi/vsgi-response.vala
+++ b/src/vsgi/vsgi-response.vala
@@ -237,6 +237,50 @@ namespace VSGI {
 #endif
 
 		/**
+		 * Expand a buffer into the response body.
+		 *
+		 * @since 0.3
+		 */
+		public bool expand (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
+			headers.set_content_length (buffer.length);
+			size_t bytes_written;
+			return write_head (out bytes_written, cancellable) &&
+			       body.write_all (buffer, out bytes_written, cancellable);
+		}
+
+		/**
+		 * Expand a UTF-8 string into the response body.
+		 *
+		 * @since 0.3
+		 */
+		public bool expand_utf8 (string body, Cancellable? cancellable = null) throws IOError {
+			return expand (body.data, cancellable);
+		}
+
+#if GIO_2_44
+		/**
+		 * @since 0.3
+		 */
+		public async bool expand_async (uint8[]      buffer,
+		                          int          priority    = GLib.Priority.DEFAULT,
+		                          Cancellable? cancellable = null) throws Error {
+			headers.set_content_length (buffer.length);
+			size_t bytes_written;
+			return (yield write_head_async (priority, cancellable, out bytes_written)) &&
+			       (yield body.write_all_async (buffer, priority, cancellable, out bytes_written));
+		}
+
+		/**
+		 * @since 0.3
+		 */
+		public async bool expand_utf8_async (string       body,
+		                                     int          priority    = GLib.Priority.DEFAULT,
+		                                     Cancellable? cancellable = null) throws Error {
+			return yield expand_async (body.data, priority, cancellable);
+		}
+#endif
+
+		/**
 		 * Write the head before disposing references to other objects.
 		 */
 		public override void dispose () {


### PR DESCRIPTION
I'm wondering if the UTF-8 expansion should set the `charset` parameter for the `Content-Type` header.

The documentation should be updated as well.

Otherwise, it's ready to merge!