### PR TITLE
router: Enforce explicit leading slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ using VSGI.HTTP;
 
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
     res.headers.set_content_type ("text/plain", null);
     return res.extend_utf8 ("Hello world!");
 });

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -38,7 +38,7 @@ a :doc:`route` instance.
 
 ::
 
-    app.get ("", (req, res, next, context) => {
+    app.get ("/", (req, res, next, context) => {
         return res.expand_utf8 ("Hello world!", null);
     });
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -32,7 +32,7 @@ the latest changes in the framework.
 
     var app = new Router ();
 
-    app.get ("", (req, res) => {
+    app.get ("/", (req, res) => {
         return res.expand_utf8 ("Hello world!");
     });
 

--- a/docs/recipes/persistence.rst
+++ b/docs/recipes/persistence.rst
@@ -35,7 +35,7 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
     var app       = new Router ();
     var memcached = new Memcached.Context ();
 
-    app.get ("<key>", (req, res) => {
+    app.get ("/<key>", (req, res) => {
         var key = req.params["key"];
 
         int32 flags;
@@ -45,7 +45,7 @@ maintained in nemequ/vala-extra-vapis GitHub repository.
         return res.expand (value, null);
     });
 
-    app.post ("<key>", (req, res) => {
+    app.post ("/<key>", (req, res) => {
         var key    = req.params["key"];
         var buffer = new MemoryOutputStream.resizable ();
 

--- a/docs/recipes/scripting.rst
+++ b/docs/recipes/scripting.rst
@@ -32,7 +32,7 @@ Lua
     var lua = new LuaVM ();
 
     // GET /lua
-    app.get ("lua", (req, res) => {
+    app.get ("/lua", (req, res) => {
         // evaluate a string containing Lua code
         res.expand_utf8 (some_lua_code, null);
 
@@ -63,7 +63,7 @@ Scheme can be used to produce template or facilitate computation.
 
 ::
 
-    app.get ("hello.scm", (req, res) => {
+    app.get ("/hello.scm", (req, res) => {
         return res.expand_utf8 (scm.run ("scripts/hello.scm"));
     });
 

--- a/docs/redirection-and-error.rst
+++ b/docs/redirection-and-error.rst
@@ -75,11 +75,11 @@ Successes are enumerated in ``Success`` error domain.
 
 ::
 
-    app.get ("document/<int:id>", (req, res) => {
+    app.get ("/document/<int:id>", (req, res) => {
         // serve the document by its identifier...
     });
 
-    app.put ("document", (req, res) => {
+    app.put ("/document", (req, res) => {
         // create the document described by the request
         throw new Success.CREATED ("/document/%u".printf (id));
     });
@@ -95,7 +95,7 @@ Redirections are enumerated in ``Redirection`` error domain.
 
 ::
 
-    app.get ("user/<id>/save", (req, res) => {
+    app.get ("/user/<id>/save", (req, res) => {
         var user = User (req.params["id"]);
 
         if (user.save ())
@@ -110,7 +110,7 @@ predefined in ``ClientError`` and ``ServerError`` error domains.
 
 ::
 
-    app.get ("not-found", (req, res) => {
+    app.get ("/not-found", (req, res) => {
         throw new ClientError.NOT_FOUND ("The requested URI was not found.");
     });
 
@@ -122,11 +122,11 @@ the :doc:`router` can handle them properly.
 
 ::
 
-    app.get ("", (req, res, next) => {
+    app.get ("/", (req, res, next) => {
         return next (req, res); // will throw a 404
     });
 
-    app.get ("", (req, res) => {
+    app.get ("/", (req, res) => {
         throw new ClientError.NOT_FOUND ("");
     });
 

--- a/docs/route.rst
+++ b/docs/route.rst
@@ -22,12 +22,12 @@ functions in :doc:`router`.
 ::
 
     // using an alias
-    app.get ("your-rule/<int:id>", (req, res) => {
+    app.get ("/your-rule/<int:id>", (req, res) => {
 
     });
 
     // using a method
-    app.rule (Request.GET, "your-rule/<int:id>", (req, res) => {
+    app.rule (Request.GET, "/your-rule/<int:id>", (req, res) => {
 
     });
 
@@ -104,7 +104,7 @@ Rule parameters are available from the routing context by their name.
 
 ::
 
-    app.get ("<controller>/<action>", (req, res, next, context) => {
+    app.get ("/<controller>/<action>", (req, res, next, context) => {
         var controller = context["controller"].get_string ();
         var action     = context["action"].get_string ();
     });
@@ -118,7 +118,7 @@ and optimized.
 
 ::
 
-    app.regex (Request.GET, new Regex ("home/?", RegexCompileFlags.OPTIMIZE), (req, res) => {
+    app.regex (Request.GET, new Regex ("/home/?", RegexCompileFlags.OPTIMIZE), (req, res) => {
         return res.body.write_all ("Matched using a regular expression.".data, true);
     });
 
@@ -126,7 +126,7 @@ Named captures are registered in the routing context.
 
 ::
 
-    app.regex (new Regex ("(?<word>\w+)", RegexCompileFlags.OPTIMIZE), (req, res, next, ctx) => {
+    app.regex (new Regex ("/(?<word>\w+)", RegexCompileFlags.OPTIMIZE), (req, res, next, ctx) => {
         var word = ctx["word"].get_string ();
     });
 
@@ -195,6 +195,6 @@ the processing of a handler.
 
 ::
 
-    app.get ("redirection", (req, res) => {
+    app.get ("/redirection", (req, res) => {
         throw new Redirection.MOVED_TEMPORAIRLY ("http://example.com");
     });

--- a/docs/vsgi/request.rst
+++ b/docs/vsgi/request.rst
@@ -51,7 +51,7 @@ as a general metadata storage for requests.
 
 ::
 
-    app.get ("<int:id>", (req, res) => {
+    app.get ("/<int:id>", (req, res) => {
         var id = req.params["id"];
     });
 
@@ -172,7 +172,7 @@ a buffer (a `GLib.MemoryOutputStream`_) and return the corresponding
 
 ::
 
-    app.post ("", (req, res) => {
+    new Server ("org.vsgi.App", (req, res) => {
         var data = Soup.Form.decode ((string) req.flatten ());
         return true;
     });

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -88,7 +88,7 @@ stream and close it properly.
 
 ::
 
-    app.get ("", (req, res) => {
+    new Server ("org.vsgi.App", (req, res) => {
         res.expand_utf8 ("Hello world!");
     })
 

--- a/examples/api-interaction/app.vala
+++ b/examples/api-interaction/app.vala
@@ -28,7 +28,7 @@ openweathermap.authenticate.connect ((msg, auth) => {
     auth.authenticate ("client_id", "secret_id");
 });
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	openweathermap.send_async.begin (new Soup.Message ("GET", "http://api.openweathermap.org/data/2.5/weather?q=Montreal&units=metric"),
 	                                 null,
 	                                 (obj, result) => {

--- a/examples/cgi/app.vala
+++ b/examples/cgi/app.vala
@@ -20,7 +20,7 @@ using VSGI.CGI;
 
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	return res.expand_utf8 ("Hello world!", null);
 });
 

--- a/examples/fastcgi/app.vala
+++ b/examples/fastcgi/app.vala
@@ -22,11 +22,11 @@ public static int main (string[] args) {
 	var app = new Router ();
 
 	// default route
-	app.get ("", (req, res) => {
+	app.get ("/", (req, res) => {
 		return res.expand_utf8 ("Hello world!", null);
 	});
 
-	app.get ("random/<int:size>", (req, res, next, context) => {
+	app.get ("/random/<int:size>", (req, res, next, context) => {
 		var size   = int.parse (context["size"].get_string ());
 		var writer = new DataOutputStream (res.body);
 

--- a/examples/json/app.vala
+++ b/examples/json/app.vala
@@ -20,7 +20,7 @@ using VSGI.HTTP;
 
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	var builder   = new Json.Builder ();
 	var generator = new Json.Generator ();
 

--- a/examples/lua/app.vala
+++ b/examples/lua/app.vala
@@ -24,7 +24,7 @@ var vm  = new LuaVM ();
 
 vm.open_libs ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	vm.do_string ("""
 		require "markdown"
 		return markdown('## Hello from lua.eval!')""");

--- a/examples/markdown/app.vala
+++ b/examples/markdown/app.vala
@@ -4,7 +4,7 @@ using VSGI.HTTP;
 
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	var doc = new Document.from_string ("# Hello world!".data, DocumentFlags.EMBED);
 	doc.compile (DocumentFlags.EMBED);
 	string markdown;

--- a/examples/memcached/app.vala
+++ b/examples/memcached/app.vala
@@ -21,7 +21,7 @@ using VSGI.HTTP;
 var app       = new Router ();
 var memcached = new Memcached.Context.from_configuration ("--SERVER=localhost".data);
 
-app.get ("<key>", (req, res, next, context) => {
+app.get ("/<key>", (req, res, next, context) => {
 	var key = context["key"].get_string ();
 
 	uint32 flags;
@@ -38,7 +38,7 @@ app.get ("<key>", (req, res, next, context) => {
 	}
 });
 
-app.put ("<key>", (req, res, next, context) => {
+app.put ("/<key>", (req, res, next, context) => {
 	var key = context["key"].get_string ();
 
 	var buffer = new MemoryOutputStream (null, realloc, free);
@@ -58,7 +58,7 @@ app.put ("<key>", (req, res, next, context) => {
 	}
 });
 
-app.delete ("<key>", (req, res, next, context) => {
+app.delete ("/<key>", (req, res, next, context) => {
 	var key = context["key"].get_string ();
 
 	var error = memcached.delete (key.data, 0);

--- a/examples/modular-app/admin-router.vala
+++ b/examples/modular-app/admin-router.vala
@@ -22,7 +22,7 @@ public class AdminRouter : Router {
 
 	construct {
 		use (authenticate);
-		rule (Method.GET | Method.POST, "admin/view", view);
+		rule (Method.GET | Method.POST, "/admin/view", view);
 	}
 
 	/**

--- a/examples/modular-app/app.vala
+++ b/examples/modular-app/app.vala
@@ -20,7 +20,7 @@ using VSGI.HTTP;
 
 var app = new Router ();
 
-app.get ("", (req, res) => {
+app.get ("/", (req, res) => {
 	return res.expand_utf8 (
 	"""
 	<!DOCTYPE html>
@@ -33,7 +33,7 @@ app.get ("", (req, res) => {
 	""", null);
 });
 
-app.rule (Method.ANY, "user/*", new UserRouter ().handle);
-app.rule (Method.ANY, "admin/*", new AdminRouter ().handle);
+app.rule (Method.ANY, "/user/*", new UserRouter ().handle);
+app.rule (Method.ANY, "/admin/*", new AdminRouter ().handle);
 
 new Server ("org.valum.example.ModularApp", app.handle).run ();

--- a/examples/modular-app/user-router.vala
+++ b/examples/modular-app/user-router.vala
@@ -21,7 +21,7 @@ using VSGI;
 public class UserRouter : Router {
 
 	construct {
-		get ("user/<int:id>", view);
+		get ("/user/<int:id>", view);
 	}
 
 	public bool view (Request req, Response res, NextCallback next, Context ctx) throws Error {

--- a/examples/scgi/app.vala
+++ b/examples/scgi/app.vala
@@ -21,16 +21,16 @@ using VSGI.SCGI;
 public int main (string[] args) {
 	var app = new Router ();
 
-	app.get ("", (req, res) => {
+	app.get ("/", (req, res) => {
 		return res.expand_utf8 ("Hello world!", null);
 	});
 
-	app.post ("", (req, res) => {
+	app.post ("/", (req, res) => {
 		res.body.splice (req.body, OutputStreamSpliceFlags.NONE);
 		return true;
 	});
 
-	app.get ("async", (req, res) => {
+	app.get ("/async", (req, res) => {
 		res.expand_utf8_async.begin ("Hello world!", Priority.DEFAULT, null);
 		return true;
 	});

--- a/src/valum/valum-router.vala
+++ b/src/valum/valum-router.vala
@@ -165,9 +165,8 @@ namespace Valum {
 		/**
 		 * Bind a callback with a custom method.
 		 *
-		 * The actual rule is rooted, scoped, anchored and compiled down to
-		 * {@link GLib.Regex}. It starts matching after the leading slash '/'
-		 * in the request URI path.
+		 * The actual rule is scoped, anchored and compiled down to a
+		 * {@link GLib.Regex}.
 		 *
 		 * @since 0.1
 		 *
@@ -178,12 +177,9 @@ namespace Valum {
 		public Route rule (Method method, string rule, owned HandlerCallback cb) {
 			var pattern = new StringBuilder ();
 
-			// root the route
-			pattern.append ("/");
-
 			// scope the route
 			foreach (var scope in scopes.head) {
-				pattern.append_printf ("%s/", scope);
+				pattern.append (scope);
 			}
 
 			pattern.append (rule);
@@ -203,9 +199,6 @@ namespace Valum {
 		 * with '^' and '$' characters and providing a pre-optimized {@link  GLib.Regex}
 		 * is useless.
 		 *
-		 * Like for the rules, the regular expression starts matching after the
-		 * scopes and the leading '/' character.
-		 *
 		 * @since 0.1
 		 *
 		 * @param method HTTP method or 'null' for any
@@ -217,12 +210,9 @@ namespace Valum {
 
 			pattern.append ("^");
 
-			// root the route
-			pattern.append ("/");
-
 			// scope the route
 			foreach (var scope in scopes.head) {
-				pattern.append_printf ("%s/", Regex.escape_string (scope));
+				pattern.append (Regex.escape_string (scope));
 			}
 
 			pattern.append (regex.get_pattern ());

--- a/tests/router-test.vala
+++ b/tests/router-test.vala
@@ -23,9 +23,9 @@ using VSGI.Mock;
  */
 public static void test_router () {
 	var router = new Router ();
-	router.get ("<int:i>", (req, res) => { return true; });
-	router.get ("<string:i>", (req, res) => { return true; });
-	router.get ("<path:i>", (req, res) => { return true; });
+	router.get ("/<int:i>", (req, res) => { return true; });
+	router.get ("/<string:i>", (req, res) => { return true; });
+	router.get ("/<path:i>", (req, res) => { return true; });
 }
 
 /**
@@ -34,7 +34,7 @@ public static void test_router () {
 public static void test_router_handle () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -55,7 +55,7 @@ public static void test_router_handle () {
 public static void test_router_get () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -74,7 +74,7 @@ public static void test_router_get () {
 public void test_router_get_default_head () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -93,7 +93,7 @@ public void test_router_get_default_head () {
 public void test_router_only_get () {
 	var router = new Router ();
 
-	router.rule (Method.ONLY_GET, "", (req, res) => {
+	router.rule (Method.ONLY_GET, "/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -112,7 +112,7 @@ public void test_router_only_get () {
 public static void test_router_post () {
 	var router = new Router ();
 
-	router.post ("", (req, res) => {
+	router.post ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -131,7 +131,7 @@ public static void test_router_post () {
 public static void test_router_put () {
 	var router = new Router ();
 
-	router.put ("", (req, res) => {
+	router.put ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -150,7 +150,7 @@ public static void test_router_put () {
 public static void test_router_delete () {
 	var router = new Router ();
 
-	router.delete ("", (req, res) => {
+	router.delete ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -169,7 +169,7 @@ public static void test_router_delete () {
 public static void test_router_head () {
 	var router = new Router ();
 
-	router.head ("", (req, res) => {
+	router.head ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -188,7 +188,7 @@ public static void test_router_head () {
 public static void test_router_options () {
 	var router = new Router ();
 
-	router.options ("", (req, res) => {
+	router.options ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -207,7 +207,7 @@ public static void test_router_options () {
 public static void test_router_trace () {
 	var router = new Router ();
 
-	router.trace ("", (req, res) => {
+	router.trace ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -226,7 +226,7 @@ public static void test_router_trace () {
 public static void test_router_connect () {
 	var router = new Router ();
 
-	router.connect ("", (req, res) => {
+	router.connect ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -244,7 +244,7 @@ public static void test_router_connect () {
 public static void test_router_patch () {
 	var router = new Router ();
 
-	router.patch ("", (req, res) => {
+	router.patch ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -338,12 +338,12 @@ public void test_router_rule_any () {
 public static void test_router_regex () {
 	var router = new Router ();
 
-	var route = router.regex (Method.GET, /home/, (req, res) => {
+	var route = router.regex (Method.GET, /\/home/, (req, res) => {
 		res.status = 418;
 		return true;
 	}) as RegexRoute;
 
-	assert ("^/home$" == route.regex.get_pattern ());
+	assert ("^\\/home$" == route.regex.get_pattern ());
 	assert (RegexCompileFlags.OPTIMIZE in route.regex.get_compile_flags ());
 
 	var request  = new Request.with_uri (new Soup.URI ("http://localhost/home"));
@@ -379,8 +379,8 @@ public static void test_router_matcher () {
 public static void test_router_scope () {
 	var router = new Router ();
 
-	router.scope ("test", (inner) => {
-		inner.get ("test", (req, res) => {
+	router.scope ("/test", (inner) => {
+		inner.get ("/test", (req, res) => {
 			res.status = 418; // I'm a teapot
 			return true;
 		});
@@ -401,7 +401,7 @@ public void test_router_scope_regex () {
 	var router = new Router ();
 
 	Route? route = null;
-	router.scope ("test", (test) => {
+	router.scope ("/test/", (test) => {
 		route = test.regex (Method.GET, /(?<id>\d+)/, (req, res) => { return true; });
 	});
 
@@ -439,7 +439,7 @@ public static void test_router_informational_switching_protocols () {
 public static void test_router_success_created () {
 	var router = new Router ();
 
-	router.put ("document", (req, res) => {
+	router.put ("/document", (req, res) => {
 		throw new Success.CREATED ("/document/5");
 	});
 
@@ -458,7 +458,7 @@ public static void test_router_success_created () {
 public static void test_router_success_partial_content () {
 	var router = new Router ();
 
-	router.put ("document", (req, res) => {
+	router.put ("/document", (req, res) => {
 		throw new Success.PARTIAL_CONTENT ("bytes 21010-47021/47022");
 	});
 
@@ -477,7 +477,7 @@ public static void test_router_success_partial_content () {
 public static void test_router_redirection () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		throw new Redirection.MOVED_TEMPORARILY ("http://example.com");
 	});
 
@@ -496,7 +496,7 @@ public static void test_router_redirection () {
 public static void test_router_client_error_method_not_allowed () {
 	var router = new Router ();
 
-	router.post ("", (req, res) => {
+	router.post ("/", (req, res) => {
 		return true;
 	});
 
@@ -538,7 +538,7 @@ public static void test_router_client_error_upgrade_required () {
 public static void test_router_server_error () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		throw new ServerError.INTERNAL_SERVER_ERROR ("Teapot's burning!");
 	});
 
@@ -564,7 +564,7 @@ public static void test_router_server_error () {
 public static void test_router_custom_method () {
 	var router = new Router ();
 
-	router.rule (Method.OTHER, "", (req, res) => {
+	router.rule (Method.OTHER, "/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
@@ -583,11 +583,11 @@ public static void test_router_custom_method () {
 public static void test_router_method_not_allowed () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		return true;
 	});
 
-	router.put ("", (req, res) => {
+	router.put ("/", (req, res) => {
 		return true;
 	});
 
@@ -597,7 +597,6 @@ public static void test_router_method_not_allowed () {
 	router.handle (request, response);
 
 	assert (response.status == 405);
-	message (response.headers.get_one ("Allow"));
 	assert ("GET, HEAD, PUT" == response.headers.get_one ("Allow"));
 }
 
@@ -633,11 +632,11 @@ public static void test_router_method_not_allowed_excludes_request_method () {
 public static void test_router_method_not_allowed_success_on_options () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		return true;
 	});
 
-	router.put ("", (req, res) => {
+	router.put ("/", (req, res) => {
 		return true;
 	});
 
@@ -647,7 +646,6 @@ public static void test_router_method_not_allowed_success_on_options () {
 	router.handle (request, response);
 
 	assert (response.status == 200);
-	message (response.headers.get_one ("Allow"));
 	assert ("GET, HEAD, PUT" == response.headers.get_one ("Allow"));
 	assert (Soup.Encoding.CONTENT_LENGTH == response.headers.get_encoding ());
 	assert (0 == response.headers.get_content_length ());
@@ -675,12 +673,12 @@ public static void test_router_subrouting () {
 	var router    = new Router ();
 	var subrouter = new Router ();
 
-	subrouter.get ("", (req, res) => {
+	subrouter.get ("/", (req, res) => {
 		res.status = 418;
 		return true;
 	});
 
-	router.get ("", subrouter.handle);
+	router.get ("/", subrouter.handle);
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
 	var response = new Response.with_status (request, Soup.Status.NOT_FOUND);
@@ -696,16 +694,16 @@ public static void test_router_subrouting () {
 public static void test_router_next () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
 	// should recurse a bit in process_routing
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		res.status = 418;
 		return true;
 	});
@@ -721,12 +719,12 @@ public static void test_router_next () {
 public static void test_router_next_not_found () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
 	// should recurse a bit in process_routing
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
@@ -746,16 +744,16 @@ public static void test_router_next_not_found () {
 public static void test_router_next_propagate_error () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next) => {
-		throw new ClientError.UNAUTHORIZED ("");
+	router.get ("/", (req, res, next) => {
+		throw new ClientError.UNAUTHORIZED ("/");
 	});
 
 	var request = new Request.with_uri (new Soup.URI ("http://localhost/"));
@@ -773,16 +771,16 @@ public static void test_router_next_propagate_state () {
 	var router = new Router ();
 	var state  = new Object ();
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		context["state"] = state;
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		res.status = 413;
 		assert (state == context["state"]);
 		return true;
@@ -803,18 +801,18 @@ public static void test_router_next_replace_propagated_state () {
 	var router = new Router ();
 	var state  = new Object ();
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		context["state"] = state;
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		assert (state == context["state"]);
 		context["state"] = "something really different";
 		return next (req, res);
 	});
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		res.status = 413;
 		assert (context["state"].holds (typeof (string)));
 		assert (context.parent["state"].holds (typeof (string)));
@@ -854,7 +852,7 @@ public static void test_router_status_propagates_error_message () {
 public void test_router_status_handle_error () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		throw new IOError.FAILED ("Just failed!");
 	});
 
@@ -877,11 +875,11 @@ public void test_router_status_handle_error () {
 public static void test_router_invoke () {
 	var router = new Router ();
 
-	router.get ("", (req, res, next) => {
+	router.get ("/", (req, res, next) => {
 		return router.invoke (req, res, next);
 	});
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		throw new ClientError.IM_A_TEAPOT ("this is insane!");
 	});
 
@@ -900,12 +898,12 @@ public static void test_router_invoke_propagate_state () {
 	var router  = new Router ();
 	var message = "test";
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		context["message"] = message;
 		return router.invoke (req, res, next);
 	});
 
-	router.get ("", (req, res, next, context) => {
+	router.get ("/", (req, res, next, context) => {
 		assert (message == context["message"].get_string ());
 		throw new ClientError.IM_A_TEAPOT ("this is insane!");
 	});
@@ -927,7 +925,7 @@ public void test_router_then () {
 	var setted      = false;
 	var then_setted = false;
 
-	router.get ("<int:id>", (req, res, next) => {
+	router.get ("/<int:id>", (req, res, next) => {
 		setted = true;
 		return next (req, res);
 	}).then ((req, res) => {
@@ -953,7 +951,7 @@ public void test_router_then_preserve_matching_context () {
 
 	var reached = false;
 
-	router.get ("<int:id>", (req, res, next, context) => {
+	router.get ("/<int:id>", (req, res, next, context) => {
 		context["test"] = "test";
 		return next (req, res);
 	}).then ((req, res, next, context) => {
@@ -977,7 +975,7 @@ public void test_router_then_preserve_matching_context () {
 public void test_router_error () {
 	var router = new Router ();
 
-	router.get ("", (req, res) => {
+	router.get ("/", (req, res) => {
 		throw new IOError.FAILED ("Just failed!");
 	});
 

--- a/tests/server-sent-events-test.vala
+++ b/tests/server-sent-events-test.vala
@@ -26,7 +26,7 @@ using VSGI.Mock;
 public void test_server_sent_events_send () {
 	var router = new Router ();
 
-	router.get ("", stream_events ((req, send) => {
+	router.get ("/", stream_events ((req, send) => {
 		send ("important", "some event", "1234", TimeSpan.MILLISECOND);
 	}));
 
@@ -58,7 +58,7 @@ public void test_server_sent_events_send () {
 public void test_server_sent_events_send_multiline () {
 	var router = new Router ();
 
-	router.get ("", stream_events ((req, send) => {
+	router.get ("/", stream_events ((req, send) => {
 		send (null, "some event\nmore details");
 	}));
 


### PR DESCRIPTION
It's semantically better and has a few advantages:

 - easier to understand as it correspond to the actual request URI
 - scoping does not add an ending slash anymore

However, the slash must be explicitly given for rules, regular expressions and scopes.