### PR TITLE
Basepath middleware

### DIFF
--- a/docs/middlewares/basepath.rst
+++ b/docs/middlewares/basepath.rst
@@ -1,0 +1,52 @@
+Basepath
+========
+
+The ``basepath`` middleware allow a better isolation when composing routers by
+stripping a prefix on the :doc:`../vsgi/request` URI.
+
+The middleware strips and forwards requests which match the provided base path.
+If the resulting path is empty, it fallbacks to a root ``/``.
+
+Error which use their message as a ``Location`` header are automatically
+prefixed by the base path.
+
+::
+
+    var user = new Router ();
+
+    user.get ("/<int:id>", (req, res) => {
+        // ...
+    });
+
+    user.post ("/", (req, res) => {
+        throw new Success.CREATED ("/5");
+    });
+
+    app.use (basepath ("/user", user.handle));
+
+    app.status (Soup.Status.CREATED, (req, res) => {
+        assert ("/user/5" == context["message"]);
+    });
+
+If ``next`` is called while forwarding or an error is thrown, the original path
+is restored.
+
+::
+
+    user.get ("/<int:id>", (req, res, next) => { 
+        return next (req, res); // path is '/5'
+    });
+
+    app.use (basepath ("/user", user.handle));
+
+    app.use ((req, res) => {
+        // path is '/user/5'
+    });
+
+One common pattern is to provide a path-based fallback when using the
+:doc:`subdomain` middleware.
+
+::
+
+    app.use (subdomain ("api", api.handle));
+    app.use (basepath ("/api", api.handle));

--- a/docs/middlewares/index.rst
+++ b/docs/middlewares/index.rst
@@ -2,5 +2,6 @@ Middlewares
 ===========
 
 .. toctree::
+    basepath
     server-sent-events
     subdomain

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -219,15 +219,14 @@ app.get ("/not-found", (req, res) => {
 
 var api = new Router ();
 
-app.use (subdomain ("api", api.handle));
-
-api.get ("/repository/<name>", (req, res, next, context) => {
+api.get ("/<name>", (req, res, next, context) => {
 	var name = context["name"].get_string ();
 	return res.expand_utf8 (name, null);
 });
 
-// delegate all other GET requests to a subrouter
-app.get ("/repository/*", api.handle);
+// delegate all requests which path starts with '/repository'
+app.use (subdomain ("api", api.handle));
+app.use (basepath ("/repository", api.handle));
 
 app.get ("/next", (req, res, next) => {
 	return next (req, res);

--- a/src/valum/valum-basepath.vala
+++ b/src/valum/valum-basepath.vala
@@ -28,6 +28,8 @@ namespace Valum {
 	 * Typically, a leading slash and no ending slash are used to form the
 	 * prefix path (e.g. '/user').
 	 *
+	 * If 'next' is called while forwarding, the URI path is restored.
+	 *
 	 * @since 0.3
 	 *
 	 * @param path
@@ -36,9 +38,13 @@ namespace Valum {
 	public HandlerCallback basepath (string path, owned HandlerCallback forward) {
 		return (req, res, next, context) => {
 			if (req.uri.get_path ().has_prefix (path)) {
+				var original_path = req.uri.get_path ();
 				req.uri.set_path (req.uri.get_path ().length > path.length ? 
 				                  req.uri.get_path ().substring (path.length) : "/");
-				return forward (req, res, next, context);
+				return forward (req, res, (req, res) => {
+					req.uri.set_path (original_path);
+					return next (req, res);
+				}, context);
 			} else {
 				return next (req, res);
 			}

--- a/src/valum/valum-basepath.vala
+++ b/src/valum/valum-basepath.vala
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using GLib;
+
+namespace Valum {
+
+	/**
+	 * Rebase and forward requests which path match the provided basepath.
+	 *
+	 * If the {@link Valum.Request.uri} path has the provided prefix, it is 
+	 * stripped and the resulting request is forwared.
+	 *
+	 * Typically, a leading slash and no ending slash are used to form the
+	 * prefix path (e.g. '/user').
+	 *
+	 * @since 0.3
+	 *
+	 * @param path
+	 * @param forward callback used to forward the request
+	 */
+	public HandlerCallback basepath (string path, owned HandlerCallback forward) {
+		return (req, res, next, context) => {
+			if (req.uri.get_path ().has_prefix (path)) {
+				req.uri.set_path (req.uri.get_path ().length > path.length ? 
+				                  req.uri.get_path ().substring (path.length) : "/");
+				return forward (req, res, next, context);
+			} else {
+				return next (req, res);
+			}
+		};
+	}
+}

--- a/src/valum/valum-basepath.vala
+++ b/src/valum/valum-basepath.vala
@@ -35,7 +35,7 @@ namespace Valum {
 	 *
 	 * @since 0.3
 	 *
-	 * @param path
+	 * @param path    path prefix stripped on forwarded requests
 	 * @param forward callback used to forward the request
 	 */
 	public HandlerCallback basepath (string path, owned HandlerCallback forward) {

--- a/src/valum/valum-basepath.vala
+++ b/src/valum/valum-basepath.vala
@@ -41,10 +41,14 @@ namespace Valum {
 				var original_path = req.uri.get_path ();
 				req.uri.set_path (req.uri.get_path ().length > path.length ? 
 				                  req.uri.get_path ().substring (path.length) : "/");
-				return forward (req, res, (req, res) => {
+				try {
+					return forward (req, res, (req, res) => {
+						req.uri.set_path (original_path);
+						return next (req, res);
+					}, context);
+				} finally {
 					req.uri.set_path (original_path);
-					return next (req, res);
-				}, context);
+				}
 			} else {
 				return next (req, res);
 			}

--- a/src/valum/valum-basepath.vala
+++ b/src/valum/valum-basepath.vala
@@ -30,6 +30,9 @@ namespace Valum {
 	 *
 	 * If 'next' is called while forwarding, the URI path is restored.
 	 *
+	 * Error which message consist of a 'Location' header are prefixed by
+	 * the basepath.
+	 *
 	 * @since 0.3
 	 *
 	 * @param path
@@ -46,6 +49,12 @@ namespace Valum {
 						req.uri.set_path (original_path);
 						return next (req, res);
 					}, context);
+				} catch (Success.CREATED s) {
+					s.message = s.message[0] == '/' ? (path + s.message) : s.message;
+					throw s;
+				} catch (Redirection r) {
+					r.message = r.message[0] == '/' ? (path + r.message) : r.message;
+					throw r;
 				} finally {
 					req.uri.set_path (original_path);
 				}

--- a/tests/basepath-test.vala
+++ b/tests/basepath-test.vala
@@ -38,5 +38,23 @@ public int main (string[] args) {
 		}
 	});
 
+	Test.add_func ("/basepath/restore_path_on_next", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req, res, next) => {
+				assert ("/" == req.uri.get_path ());
+				return next (req, res);
+			}) (req, res, () => {
+				assert ("/base" == req.uri.get_path ());
+				return true;
+			}, ctx);
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
 	return Test.run ();
 }

--- a/tests/basepath-test.vala
+++ b/tests/basepath-test.vala
@@ -56,5 +56,24 @@ public int main (string[] args) {
 		}
 	});
 
+	Test.add_func ("/basepath/restore_path_on_error", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req, res, next) => {
+				assert ("/" == req.uri.get_path ());
+				throw new ClientError.NOT_FOUND ("");
+			}) (req, res, () => {
+				assert_not_reached ();
+			}, ctx);
+		} catch (ClientError.NOT_FOUND r) {
+			assert ("/base" == req.uri.get_path ());
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
 	return Test.run ();
 }

--- a/tests/basepath-test.vala
+++ b/tests/basepath-test.vala
@@ -75,5 +75,45 @@ public int main (string[] args) {
 		}
 	});
 
+	Test.add_func ("/basepath/success_created/prefix_message", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req, res, next) => {
+				assert ("/" == req.uri.get_path ());
+				throw new Success.CREATED ("/5");
+			}) (req, res, () => {
+				assert_not_reached ();
+			}, ctx);
+		} catch (Success.CREATED s) {
+			assert ("/base/5" == s.message);
+			assert ("/base" == req.uri.get_path ());
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
+	Test.add_func ("/basepath/success_created/omit_non_relative_message", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req, res, next) => {
+				assert ("/" == req.uri.get_path ());
+				throw new Success.CREATED ("http://localhost/5");
+			}) (req, res, () => {
+				assert_not_reached ();
+			}, ctx);
+		} catch (Success.CREATED s) {
+			assert ("http://localhost/5" == s.message);
+			assert ("/base" == req.uri.get_path ());
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
 	return Test.run ();
 }

--- a/tests/basepath-test.vala
+++ b/tests/basepath-test.vala
@@ -1,0 +1,42 @@
+using Valum;
+using VSGI.Mock;
+
+public int main (string[] args) {
+	Test.init (ref args);
+
+	Test.add_func ("/basepath", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base/"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req) => {
+				assert ("/" == req.uri.get_path ());
+				return true;
+			}) (req, res, () => {
+				assert_not_reached ();
+			}, ctx);
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
+	Test.add_func ("/basepath/empty_path", () => {
+		var req = new Request.with_uri (new Soup.URI ("http://localhost/base"));
+		var res = new Response (req);
+		var ctx = new Context ();
+
+		try {
+			basepath ("/base", (req) => {
+				assert ("/" == req.uri.get_path ());
+				return true;
+			}) (req, res, () => {
+				assert_not_reached ();
+			}, ctx);
+		} catch (Error err) {
+			assert_not_reached ();
+		}
+	});
+
+	return Test.run ();
+}

--- a/tests/wscript
+++ b/tests/wscript
@@ -11,7 +11,7 @@ def build(bld):
     bld.program(
         features     = 'test',
         target       = 'tests',
-        source       = bld.path.ant_glob('*.vala', excl='vsgi-test.vala') + ['tests.gresource.xml'],
+        source       = bld.path.ant_glob('*.vala', excl='vsgi-test.vala basepath-test.vala') + ['tests.gresource.xml'],
         use          = 'valum',
         install_path = None)
     bld.program(
@@ -19,6 +19,12 @@ def build(bld):
         target       = 'vsgi-test',
         source       = 'vsgi-test.vala',
         use          = 'vsgi vsgi-mock',
+        install_path = None)
+    bld.program(
+        features     = 'test',
+        target       = 'basepath-test',
+        source       = 'basepath-test.vala',
+        use          = 'valum',
         install_path = None)
     from waflib.Tools import waf_unit_test
     bld.add_post_fun(waf_unit_test.summary)


### PR DESCRIPTION
The `basepath` middleware provide a way of stripping a path prefix, which is very handy when composing routers.

 - strip the basepath on incoming requests
 - rewrite thrown error that use the message as `Location` header
 - restore the original path if `next` is called while forwarding

@Bob131 feedback?