### PR TITLE
Build with multiple versions of 'valac'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,16 @@ cache:
 compiler:
     - gcc
 
+env:
+    - VALAC=valac-0.26
+    - VALAC=valac-0.28
+    - VALAC=valac-0.30
+    - VALAC=valac
+
 before_install:
     - sudo add-apt-repository --yes ppa:vala-team
     - sudo apt-get update --quiet
-    - sudo apt-get install --yes --force-yes valac-0.26 libglib2.0-bin
+    - sudo apt-get install --yes --force-yes ${VALAC} libglib2.0-bin
       libglib2.0-dev libsoup2.4-dev libfcgi-dev python3-pip gcovr libgee-0.8-dev
       libctpl-dev libjson-glib-dev libmemcached-dev libmarkdown2-dev
       liblua5.2-dev

--- a/examples/memcached/vapi/libmemcached.vapi
+++ b/examples/memcached/vapi/libmemcached.vapi
@@ -535,7 +535,9 @@ namespace Memcached {
     ulonglong get_hits;
     ulonglong get_misses;
     ulonglong limit_maxbytes;
+#if VALA_0_26
     uint8 version[Memcached.VERSION_STRING_LENGTH];
+#endif
     void* __future;
     Memcached.Context root;
   }

--- a/src/valum/valum-context.vala
+++ b/src/valum/valum-context.vala
@@ -85,9 +85,11 @@ public class Valum.Context : Object {
 	 * @return    the value, or 'null' if not found
 	 */
 	public Value? take (string key) {
-		bool exists;
-		var @value = states.take (key, out exists);
-		return exists ? @value : null;
+		try {
+			return states.lookup (key);
+		} finally {
+			states.steal (key);
+		}
 	}
 
 	/**


### PR DESCRIPTION
It builds with at least `0.26`, which is pretty good already!

For lower versions provided on Ubuntu 14.04:

 - `0.22` has older VAPIs for `gio-2.0` so more preprocessor directives would be required
 - `0.24` produce a SEGFAULT #167 

Tests for the FastCGI and `SocketListenerServer` servers should use a random open port because they fail for using `3003`.