### PR TITLE
Split 'write_head' into 'write_status_line' and 'write_headers'

### DIFF
--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -112,16 +112,6 @@ The body of a response is accessed through the ``body`` property. It inherits
 from `GLib.OutputStream`_ and provides synchronous and asynchronous streaming
 capabilities.
 
-It's also possible to obtain the body asynchronously as it might trigger
-a blocking call call to ``write_head``.
-
-::
-
-    res.get_body_async.begin (Priority.DEFAULT, null, (obj, result) => {
-        var body = res.get_body_async.end (result);
-        body.write_all ("Hello world!".data, null);
-    });
-
 The response body is automatically closed following a RAII pattern whenever the
 ``Response`` object is disposed.
 

--- a/docs/vsgi/response.rst
+++ b/docs/vsgi/response.rst
@@ -44,6 +44,17 @@ The reason phrase provide a textual description for the status code. If
 
 .. _Soup.Status.get_phrase: http://valadoc.org/#!api=libsoup-2.4/Soup.Status.get_phrase
 
+To obtain final status line sent to the user agent, use the ``wrote_status_line``
+signal.
+
+::
+
+    res.wrote_status_line.connect ((http_version, status, reason_phrase) => {
+        if (200 <= status < 300) {
+            // assuming a success
+        }
+    });
+
 Headers
 -------
 
@@ -83,17 +94,14 @@ even though a well written application should assume that already.
         res.headers.set_content_type ("text/html", null);
     }
 
-Since ``head_written`` is a property, it's possible to capture it's change
-using the ``notify`` signal.
-
-Since status, reason phrase and headers cannot be modified once written, this
-event can be used to trigger work that would assume a successful response.
+Since headers can still be modified once written, the ``wrote_headers`` signal
+can be used to obtain definitive values.
 
 ::
 
-    res.notify["head-written"].connect (() => {
-        if (res.head_written && res.status == 200) {
-            // perform some work assuming a '200 OK' response
+    res.wrote_headers (() => {
+        foreach (var cookie in res.cookies) {
+            message (cookie.to_set_cookie_header ());
         }
     });
 

--- a/examples/app/app.vala
+++ b/examples/app/app.vala
@@ -20,18 +20,6 @@ using Valum.ContentNegotiation;
 using Valum.ServerSentEvents;
 using VSGI;
 
-public async void respond_async (VSGI.Request req, VSGI.Response res) throws Error {
-	size_t bytes_written;
-	var body    = yield res.get_body_async (Priority.DEFAULT, null, out bytes_written);
-#if GIO_2_44
-	yield body.write_all_async ("Hello world!".data, Priority.DEFAULT, null, out bytes_written);
-#else
-	body.write_all ("Hello world!".data, out bytes_written);
-#endif
-	yield body.close_async ();
-}
-
-
 var app = new Router ();
 
 app.use (basic ());
@@ -61,7 +49,7 @@ app.get ("/", (req, res, next) => {
 });
 
 app.get ("/async", (req, res) => {
-	respond_async.begin (req, res);
+	res.expand_utf8_async.begin ("Hello world!");
 	return true;
 });
 

--- a/src/vsgi/servers/vsgi-http.vala
+++ b/src/vsgi/servers/vsgi-http.vala
@@ -153,10 +153,23 @@ namespace VSGI.HTTP {
 		 * {@inheritDoc}
 		 *
 		 * Implementation based on {@link Soup.Message} already handles the
-		 * writing of the status line and headers, so an empty buffer is
-		 * returned.
+		 * writing of the status line.
 		 */
-		protected override uint8[]? build_head () { return null; }
+		protected override bool write_status_line (HTTPVersion http_version, uint status, string reason_phrase, out size_t bytes_written, Cancellable? cancellable = null) {
+			bytes_written = 0;
+			return true;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Implementation based on {@link Soup.Message} already handles the
+		 * writing of the headers.
+		 */
+		protected override bool write_headers (MessageHeaders headers, out size_t bytes_written, Cancellable? cancellable = null) {
+			bytes_written= 0;
+			return true;
+		}
 	}
 
 	/**

--- a/src/vsgi/vsgi-cgi.vala
+++ b/src/vsgi/vsgi-cgi.vala
@@ -164,6 +164,25 @@ namespace VSGI.CGI {
 			Object (request: request);
 		}
 
+		/**
+		 * On the first attempt to access the response body stream, the status
+		 * line and headers will be written synchronously in the response
+		 * stream. 'write_head_async' have to be used explicitly to perform a
+		 * non-blocking operation.
+		 */
+		public override OutputStream body {
+			get {
+				try {
+					// write head synchronously
+					size_t bytes_written;
+					write_head (out bytes_written);
+				} catch (IOError err) {
+					critical ("could not write the head in the connection stream: %s", err.message);
+				}
+				return base.body;
+			}
+		}
+
 		protected override bool write_status_line (HTTPVersion  http_version,
 		                                           uint         status,
 		                                           string       reason_phrase,

--- a/src/vsgi/vsgi-mock.vala
+++ b/src/vsgi/vsgi-mock.vala
@@ -124,5 +124,26 @@ namespace VSGI.Mock {
 		public Response.with_status (Request req, uint status) {
 			Object (request: req, status: status);
 		}
+
+		protected override bool write_status_line (HTTPVersion http_version, uint status, string reason_phrase, out size_t bytes_written, Cancellable? cancellable = null)  throws IOError {
+			return request.connection.output_stream.write_all ("HTTP/%s %u %s\r\n".printf (http_version == HTTPVersion.@1_0 ? "1.0" : "1.1", status, reason_phrase).data,
+			                                                   out bytes_written,
+			                                                   cancellable);
+		}
+
+		protected override bool write_headers (MessageHeaders headers, out size_t bytes_written, Cancellable?
+				cancellable = null) throws IOError {
+			var head = new StringBuilder ();
+
+			// headers
+			headers.@foreach ((name, header) => {
+				head.append_printf ("%s: %s\r\n", name, header);
+			});
+
+			// newline preceeding the body
+			head.append ("\r\n");
+
+			return request.connection.output_stream.write_all (head.str.data, out bytes_written, cancellable);
+		}
 	}
 }

--- a/src/vsgi/vsgi-response.vala
+++ b/src/vsgi/vsgi-response.vala
@@ -99,11 +99,6 @@ namespace VSGI {
 		/**
 		 * Response body.
 		 *
-		 * On the first attempt to access the response body stream, the status
-		 * line and headers will be written synchronously in the response
-		 * stream. 'write_head_async' have to be used explicitly to perform a
-		 * non-blocking operation.
-		 *
 		 * The provided stream is safe for transfer encoding and will filter
 		 * the stream properly if it's chunked.
 		 *
@@ -117,38 +112,10 @@ namespace VSGI {
 		 *
 		 * @since 0.2
 		 */
-		public OutputStream body {
+		public virtual OutputStream body {
 			get {
-				try {
-					// write head synchronously
-					size_t bytes_written;
-					write_head (out bytes_written);
-				} catch (IOError err) {
-					critical ("could not write the head in the connection stream: %s", err.message);
-				}
-
 				return _body ?? this.request.connection.output_stream;
 			}
-		}
-
-		/**
-		 * Obtain the body stream asynchronously.
-		 *
-		 * Unlike the {@link VSGI.Request.body} property, this allow you to
-		 * asynchronously obtain the body when the head has been written in
-		 * a single call.
-		 *
-		 * @since 0.3
-		 */
-		public async OutputStream get_body_async (int priority             = GLib.Priority.DEFAULT,
-		                                          Cancellable? cancellable = null,
-		                                          out size_t   bytes_written) throws Error {
-			if (head_written) {
-				bytes_written = 0;
-			} else {
-				yield write_head_async (priority, cancellable, out bytes_written);
-			}
-			return body;
 		}
 
 		/**

--- a/src/vsgi/vsgi-response.vala
+++ b/src/vsgi/vsgi-response.vala
@@ -77,6 +77,8 @@ namespace VSGI {
 			}
 		}
 
+		private size_t _head_written = 0;
+
 		/**
 		 * Tells if the head has been written in the connection
 		 * {@link GLib.OutputStream}.
@@ -85,7 +87,7 @@ namespace VSGI {
 		 *
 		 * @since 0.2
 		 */
-		public virtual bool head_written { get; protected set; default = false; }
+		public bool head_written { get { return _head_written > 0; } }
 
 		/**
 		 * Placeholder for the response body.
@@ -152,42 +154,72 @@ namespace VSGI {
 		}
 
 		/**
-		 * Produce the head of this response including the status line, the
-		 * headers and the newline preceeding the body as it would be written in
-		 * the base stream.
+		 * Emitted when the status line has been written.
 		 *
-		 * The default implementation will produce a valid HTTP/1.1 head
-		 * including the status line and headers.
-		 *
-		 * @since 0.2
+		 * @since 0.3
 		 */
-		protected virtual uint8[]? build_head () {
-			var head = new StringBuilder ();
+		public signal void wrote_status_line (uint status, string reason_phrase);
 
-			// status line
-			head.append_printf ("HTTP/%s %u %s\r\n",
-			                    this.request.http_version == HTTPVersion.@1_0 ? "1.0" : "1.1",
-			                    status,
-			                    reason_phrase ?? Status.get_phrase (status));
+		/**
+		 * Emitted when the headers has been written.
+		 *
+		 * @since 0.3
+		 */
+		public signal void wrote_headers (Soup.MessageHeaders headers);
 
-			// headers
-			this.headers.foreach ((name, header) => {
-				head.append_printf ("%s: %s\r\n", name, header);
-			});
+		/**
+		 * Send the status line to the client.
+		 *
+		 * @since 0.3
+		 */
+		protected abstract bool write_status_line (HTTPVersion http_version, uint status, string reason_phrase, out size_t bytes_written, Cancellable? cancellable = null) throws IOError;
 
-			// newline preceeding the body
-			head.append ("\r\n");
-
-			return head.str.data;
+		/**
+		 * @since 0.3
+		 */
+		protected virtual async bool write_status_line_async (HTTPVersion  http_version,
+		                                                      uint         status,
+		                                                      string       reason_phrase,
+		                                                      int          priority    = GLib.Priority.DEFAULT,
+		                                                      Cancellable? cancellable = null,
+		                                                      out size_t   bytes_written) throws Error {
+			return write_status_line (http_version, status, reason_phrase, out bytes_written, cancellable);
 		}
 
 		/**
-		 * Write status line and headers into the base stream.
+		 * Send headers to the client.
+		 *
+		 * @since 0.3
+		 */
+		protected abstract bool write_headers (MessageHeaders headers,
+		                                       out size_t     bytes_written,
+		                                       Cancellable?   cancellable = null) throws IOError;
+
+		/**
+		 * @since 0.3
+		 */
+		protected virtual async bool write_headers_async (MessageHeaders headers,
+		                                                  int            priority    = GLib.Priority.DEFAULT,
+		                                                  Cancellable?   cancellable = null,
+		                                                  out size_t     bytes_written) throws Error {
+			return write_headers (headers, out bytes_written, cancellable);
+		}
+
+		/**
+		 * Write status line and headers into the connection stream, emitting
+		 * 'wrote-status-line' and 'wrote-headers' signals in the process.
 		 *
 		 * This is invoked automatically when accessing the response body for
 		 * the first time.
 		 *
+		 * Once the 'wrote-status-line' has been emmitted, its handler is free
+		 * to modify the response headers accordingly.
+		 *
+		 * Once the 'wrote-headers' has been emmited, its handler may still
+		 * apply converter on the body.
+		 *
 		 * @since 0.2
+		 *
 		 *
 		 * @param bytes_written number of bytes written in the stream see
 		 *                      {@link GLib.OutputStream.write_all}
@@ -196,51 +228,68 @@ namespace VSGI {
 		public bool write_head (out size_t bytes_written, Cancellable? cancellable = null) throws IOError
 			requires (!this.head_written)
 		{
-			var head = this.build_head ();
+			if (Once.init_enter (&_head_written)) {
+				try {
+					write_status_line (request.http_version,
+					                   status,
+					                   reason_phrase ?? Status.get_phrase (status),
+					                   out bytes_written, cancellable);
+					wrote_status_line (status, reason_phrase ?? Status.get_phrase (status));
 
-			if (head == null) {
-				bytes_written = 0;
-				this.head_written = true;
+					var headers_copy = new MessageHeaders (MessageHeadersType.REQUEST);
+					headers.@foreach (headers_copy.append);
+
+					size_t headers_bytes_written;
+					write_headers (headers_copy, out headers_bytes_written, cancellable);
+					wrote_headers (headers_copy);
+
+					bytes_written += headers_bytes_written;
+
+					return true;
+				} finally {
+					Once.init_leave (&_head_written, 1);
+				}
 			} else {
-				this.head_written = this.request.connection.output_stream.write_all (head,
-				                                                                     out bytes_written,
-				                                                                     cancellable);
+				bytes_written = 0;
+				return true;
 			}
-
-			return this.head_written;
 		}
 
 		/**
-		 * Write status line and headers asynchronously.
-		 *
-		 * @since 0.2
-		 *
-		 * @param bytes_written number of bytes written in the stream see
-		 *                      {@link GLib.OutputStream.write_all_async}
-		 * @return wether the head was effectively written
+		 * @since 0.3
 		 */
-		public async bool write_head_async (int priority = GLib.Priority.DEFAULT,
+		public async bool write_head_async (int          priority    = GLib.Priority.DEFAULT,
 		                                    Cancellable? cancellable = null,
-		                                    out size_t bytes_written) throws Error
+		                                    out size_t   bytes_written) throws Error
 			requires (!this.head_written)
 		{
-#if GIO_2_44
-			var head = this.build_head ();
+			if (Once.init_enter (&_head_written)) {
+				try {
+					yield write_status_line_async (request.http_version,
+					                               status,
+					                               reason_phrase ?? Status.get_phrase (status),
+					                               priority,
+					                               cancellable,
+					                               out bytes_written);
+					wrote_status_line (status, reason_phrase ?? Status.get_phrase (status));
 
-			if (head == null) {
-				bytes_written = 0;
-				this.head_written = true;
+					var headers_copy = new MessageHeaders (MessageHeadersType.REQUEST);
+					headers.@foreach (headers_copy.append);
+
+					size_t headers_bytes_written;
+					yield write_headers_async (headers_copy, priority, cancellable, out headers_bytes_written);
+					wrote_headers (headers_copy);
+
+					bytes_written += headers_bytes_written;
+
+					return true;
+				} finally {
+					Once.init_leave (&_head_written, 1);
+				}
 			} else {
-				this.head_written = yield this.request.connection.output_stream.write_all_async (head,
-																								 priority,
-																								 cancellable,
-																								 out bytes_written);
+				bytes_written = 0;
+				return true;
 			}
-
-			return this.head_written;
-#else
-			return write_head (out bytes_written, cancellable);
-#endif
 		}
 
 		/**

--- a/tests/response-test.vala
+++ b/tests/response-test.vala
@@ -3,6 +3,34 @@ using VSGI.Mock;
 public int main (string[] args) {
 	Test.init (ref args);
 
+	Test.add_func ("/response/write_head", () => {
+		var res = new Response (new Request (new Connection (), "GET", new Soup.URI ("http://localhost:3003/")));
+
+		var wrote_status_line_emitted = false;
+		var wrote_headers_emitted     = false;
+
+		res.wrote_status_line.connect ((status, reason_phrase) => {
+			assert (Soup.Status.OK == status);
+			assert ("OK" == reason_phrase);
+			wrote_status_line_emitted = true;
+		});
+
+		res.wrote_headers.connect ((headers) => {
+			assert (res.headers != headers);
+			wrote_headers_emitted = true;
+		});
+
+		try {
+			size_t bytes_written;
+			assert (res.write_head (out bytes_written));
+		} catch (IOError err) {
+			assert_not_reached ();
+		}
+
+		assert (wrote_status_line_emitted);
+		assert (wrote_headers_emitted);
+	});
+
 	Test.add_func ("/response/expand", () => {
 		var res = new Response (new Request (new Connection (), "GET", new Soup.URI ("http://localhost:3003/")));
 		try {


### PR DESCRIPTION
Some protocols like 'HTTP/2.0' use different channels for sending headers and body resulting in the possibility of having parts of the body emitted while not all headers are sent. This is while splitting `Response.write_head` is very convenient.

Automatically calling a writer should be implementation-specific, so we don't write headers when the body is first accessed.

`Response.head_written` is replaced by a flag covering the following conditions:

 - status line written
 - headers written

It's not possible to reliably know when the body has been written.

It's handy to have a final status line but not yet headers, especially if one wants to generate headers based on a specific status.

```vala
res.wrote_status_line.connect (() => {
    // status line is final
    if (res.is_cacheable ()) {
        res.headers.append ("Cache-Control", "public");
    }
});
```

There's some tests to fix and probably add cover new edge cases.