### PR TITLE
Fix ownership on 'NextCallback'

### DIFF
--- a/examples/modular-app/admin-router.vala
+++ b/examples/modular-app/admin-router.vala
@@ -28,7 +28,7 @@ public class AdminRouter : Router {
 	/**
 	 * Verify the user credentials and perform an authentication.
 	 */
-	public bool authenticate (Request req, Response res, NextCallback next) throws Error {
+	public bool authenticate (Request req, Response res, owned NextCallback next) throws Error {
 		string @value;
 		req.lookup_signed_cookie ("session", ChecksumType.SHA256, "impossible to break".data, out @value);
 		if (@value == "admin") {
@@ -65,7 +65,7 @@ public class AdminRouter : Router {
 	/**
 	 * Restricted content.
 	 */
-	public bool view (Request req, Response res, NextCallback next, Context ctx) throws Error {
+	public bool view (Request req, Response res, owned NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
 		return res.expand_utf8 ("Hello admin!", null);
 	}

--- a/examples/modular-app/user-router.vala
+++ b/examples/modular-app/user-router.vala
@@ -24,7 +24,7 @@ public class UserRouter : Router {
 		get ("/user/<int:id>", view);
 	}
 
-	public bool view (Request req, Response res, NextCallback next, Context ctx) throws Error {
+	public bool view (Request req, Response res, owned NextCallback next, Context ctx) throws Error {
 		res.headers.set_content_type ("text/plain", null);
 		return res.expand_utf8 ("Hello, user %s!".printf (ctx["id"].get_string ()), null);
 	}

--- a/src/valum/valum-forward.vala
+++ b/src/valum/valum-forward.vala
@@ -26,7 +26,7 @@ namespace Valum {
 	 *
 	 * @since 0.3
 	 */
-	public bool forward (Request req, Response res, NextCallback next) throws Error {
+	public bool forward (Request req, Response res, owned NextCallback next) throws Error {
 		return next ();
 	}
 }

--- a/src/valum/valum-router.vala
+++ b/src/valum/valum-router.vala
@@ -276,7 +276,7 @@ namespace Valum {
 		private bool perform_routing (SequenceIter<Route> routes,
 		                              Request req,
 		                              Response res,
-		                              NextCallback next,
+		                              owned NextCallback next,
 		                              Context context) throws Informational,
 		                                                      Success,
 		                                                      Redirection,
@@ -292,7 +292,7 @@ namespace Valum {
 						if (node.next ().is_end ()) {
 							return next ();
 						} else {
-							return perform_routing (node.next (), req, res, next, local_context);
+							return perform_routing (node.next (), req, res, (owned) next, local_context);
 						}
 					}, local_context);
 				}

--- a/src/valum/valum.vala
+++ b/src/valum/valum.vala
@@ -66,7 +66,7 @@ namespace Valum {
 	 */
 	public delegate bool HandlerCallback (Request req,
 	                                      Response res,
-	                                      NextCallback next,
+	                                      owned NextCallback next,
 	                                      Context context) throws Informational,
 	                                                              Success,
 	                                                              Redirection,
@@ -82,7 +82,7 @@ namespace Valum {
 	 */
 	public delegate bool ForwardCallback<T> (Request      req,
 	                                         Response     res,
-	                                         NextCallback next,
+	                                         owned NextCallback next,
 	                                         Context      context,
 	                                         T            @value) throws Error;
 

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -70,6 +70,7 @@ public int main (string[] args) {
 	Test.add_func ("/router/subrouting", test_router_subrouting);
 
 	Test.add_func ("/router/next", test_router_next);
+	Test.add_func ("/router/next/in_thread", test_router_next_in_thread);
 	Test.add_func ("/router/next/not_found", test_router_next_not_found);
 	Test.add_func ("/router/next/propagate_error", test_router_next_propagate_error);
 	Test.add_func ("/router/next/propagate_state", test_router_next_propagate_state);


### PR DESCRIPTION
One big drawback of not passing the 'NextCallback' ownership forward is that it cannot be called after the callee has returned (e.g. in a thread or asynchronously).

In the short-term, this is going to be really convenient to use threads for processing requests. It is necessary to build a threading middleware that would dispatch requests handling in a pool.

It's still bugging with the context being null, so there's some investigation to be performed.