### PR TITLE
vsgi: Rewrite FastCGI I/O streams in C (fix #171)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,11 @@
 [*]
 trim_trailing_whitespace=true
 
+[*.c]
+indent_style=tab
+indent_size=4
+max_line_length=120
+
 [*.vala]
 indent_style=tab
 indent_size=4

--- a/src/vsgi/servers/meson.build
+++ b/src/vsgi/servers/meson.build
@@ -13,8 +13,9 @@ shared_library('vsgi-cgi', 'vsgi-cgi.vala',
 fcgi = meson.get_compiler('c').find_library('fcgi', required: false)
 if fcgi.found()
     fcgi_vapi = meson.get_compiler('vala').find_library('fcgi', dirs: meson.current_source_dir())
-    shared_library('vsgi-fastcgi', 'vsgi-fastcgi.vala',
-                   dependencies: [glib, gobject, gio, gio_unix, soup, vsgi, fcgi, fcgi_vapi],
+    vsgi_fastcgi_internal = meson.get_compiler('vala').find_library('vsgi-fastcgi-internal', dirs: meson.current_source_dir())
+    shared_library('vsgi-fastcgi', ['vsgi-fastcgi.vala', 'vsgi-fastcgi-input-stream.c', 'vsgi-fastcgi-output-stream.c'],
+                   dependencies: [glib, gobject, gio, gio_unix, soup, vsgi, fcgi, fcgi_vapi, vsgi_fastcgi_internal],
                    vala_args: vala_defines,
                    install: true,
                    install_dir: '@0@/vsgi-@1@/servers'.format(get_option('libdir'), api_version))

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.c
@@ -31,6 +31,11 @@ vsgi_fastcgi_input_stream_real_read (GInputStream  *self,
 
 	in_stream = VSGI_FASTCGI_INPUT_STREAM (self)->priv->in;
 
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return -1;
+	}
+
 	ret = FCGX_GetStr (buffer, count, in_stream);
 
 	if (G_UNLIKELY (ret == -1))
@@ -62,6 +67,11 @@ vsgi_fastcgi_input_stream_real_close (GInputStream  *self,
 	g_return_val_if_fail (VSGI_FASTCGI_IS_INPUT_STREAM (self), FALSE);
 
 	in_stream = VSGI_FASTCGI_INPUT_STREAM (self)->priv->in;
+
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return FALSE;
+	}
 
 	ret = FCGX_FClose (in_stream);
 

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.c
@@ -1,4 +1,3 @@
-#include "vsgi-fastcgi.h"
 #include "vsgi-fastcgi-input-stream.h"
 
 typedef struct
@@ -16,7 +15,32 @@ G_DEFINE_TYPE_WITH_PRIVATE (VSGIFastCGIInputStream,
                             vsgi_fastcgi_input_stream,
                             G_TYPE_UNIX_INPUT_STREAM)
 
-gssize
+static const gchar *
+vsgi_fastcgi_strerror (int err)
+{
+	if (err > 0)
+	{
+		return g_strerror (err);
+	}
+	else
+	{
+		switch (err)
+		{
+			case FCGX_CALL_SEQ_ERROR:
+				return "FCXG: Call seq error";
+			case FCGX_PARAMS_ERROR:
+				return "FCGX: Params error";
+			case FCGX_PROTOCOL_ERROR:
+				return "FCGX: Protocol error";
+			case FCGX_UNSUPPORTED_VERSION:
+				return "FCGX: Unsupported version";
+			default:
+				g_assert_not_reached ();
+		}
+	}
+}
+
+static gssize
 vsgi_fastcgi_input_stream_real_read (GInputStream  *self,
                                      void          *buffer,
                                      gsize          count,
@@ -55,7 +79,7 @@ vsgi_fastcgi_input_stream_real_read (GInputStream  *self,
 	return ret;
 }
 
-gboolean
+static gboolean
 vsgi_fastcgi_input_stream_real_close (GInputStream  *self,
                                       GCancellable  *cancellable,
                                       GError       **error)

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.c
@@ -1,0 +1,108 @@
+#include "vsgi-fastcgi.h"
+#include "vsgi-fastcgi-input-stream.h"
+
+typedef struct
+{
+	FCGX_Stream *in;
+} VSGIFastCGIInputStreamPrivate;
+
+struct _VSGIFastCGIInputStream
+{
+	GUnixInputStream               parent_instance;
+	VSGIFastCGIInputStreamPrivate *priv;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (VSGIFastCGIInputStream,
+                            vsgi_fastcgi_input_stream,
+                            G_TYPE_UNIX_INPUT_STREAM)
+
+gssize
+vsgi_fastcgi_input_stream_real_read (GInputStream  *self,
+                                     void          *buffer,
+                                     gsize          count,
+                                     GCancellable  *cancellable,
+                                     GError       **error)
+{
+	FCGX_Stream *in_stream;
+	gint ret;
+	gint err;
+
+	g_return_val_if_fail (VSGI_FASTCGI_IS_INPUT_STREAM (self), -1);
+
+	in_stream = VSGI_FASTCGI_INPUT_STREAM (self)->priv->in;
+
+	ret = FCGX_GetStr (buffer, count, in_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (in_stream);
+
+		g_set_error (error,
+		             G_IO_ERROR,
+		             g_io_error_from_errno (err),
+		             vsgi_fastcgi_strerror (err));
+
+		FCGX_ClearError (in_stream);
+
+		return -1;
+	}
+
+	return ret;
+}
+
+gboolean
+vsgi_fastcgi_input_stream_real_close (GInputStream  *self,
+                                      GCancellable  *cancellable,
+                                      GError       **error)
+{
+	FCGX_Stream *in_stream;
+	gint ret;
+	gint err;
+
+	g_return_val_if_fail (VSGI_FASTCGI_IS_INPUT_STREAM (self), FALSE);
+
+	in_stream = VSGI_FASTCGI_INPUT_STREAM (self)->priv->in;
+
+	ret = FCGX_FClose (in_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (in_stream);
+
+		g_set_error (error,
+		             G_IO_ERROR,
+		             g_io_error_from_errno (err),
+		             vsgi_fastcgi_strerror (err));
+
+		FCGX_ClearError (in_stream);
+
+		return FALSE;
+	}
+
+    return in_stream->isClosed;
+}
+
+static void
+vsgi_fastcgi_input_stream_init (VSGIFastCGIInputStream *self)
+{
+	self->priv = vsgi_fastcgi_input_stream_get_instance_private (self);
+}
+
+static void
+vsgi_fastcgi_input_stream_class_init (VSGIFastCGIInputStreamClass *klass)
+{
+	klass->parent_class.parent_class.read_fn = vsgi_fastcgi_input_stream_real_read;
+	klass->parent_class.parent_class.close_fn = vsgi_fastcgi_input_stream_real_close;
+}
+
+VSGIFastCGIInputStream*
+vsgi_fastcgi_input_stream_new (gint fd, FCGX_Stream* in)
+{
+	VSGIFastCGIInputStream *self;
+
+	self = g_object_new (VSGI_FASTCGI_TYPE_INPUT_STREAM, "fd", fd, NULL);
+
+	self->priv->in = in;
+
+	return self;
+}

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "vsgi-fastcgi-input-stream.h"
 
 typedef struct

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.h
@@ -26,7 +26,16 @@
 G_BEGIN_DECLS
 
 #define VSGI_FASTCGI_TYPE_INPUT_STREAM (vsgi_fastcgi_input_stream_get_type ())
-G_DECLARE_FINAL_TYPE (VSGIFastCGIInputStream, vsgi_fastcgi_input_stream, VSGI_FASTCGI, INPUT_STREAM, GUnixInputStream)
+GType vsgi_fastcgi_input_stream_get_type (void);
+
+typedef struct _VSGIFastCGIInputStream VSGIFastCGIInputStream;
+
+typedef struct {
+    GUnixInputStreamClass parent_class;
+} VSGIFastCGIInputStreamClass;
+
+#define VSGI_FASTCGI_INPUT_STREAM(ptr) G_TYPE_CHECK_INSTANCE_CAST (ptr, vsgi_fastcgi_input_stream_get_type (), VSGIFastCGIInputStream)
+#define VSGI_FASTCGI_IS_INPUT_STREAM(ptr) G_TYPE_CHECK_INSTANCE_TYPE (ptr, vsgi_fastcgi_input_stream_get_type ())
 
 VSGIFastCGIInputStream * vsgi_fastcgi_input_stream_new (gint fd, FCGX_Stream *in);
 

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef __VSGI_FASTCGI_INPUT_STREAM_H__
 #define __VSGI_FASTCGI_INPUT_STREAM_H__
 

--- a/src/vsgi/servers/vsgi-fastcgi-input-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-input-stream.h
@@ -1,0 +1,18 @@
+#ifndef __VSGI_FASTCGI_INPUT_STREAM_H__
+#define __VSGI_FASTCGI_INPUT_STREAM_H__
+
+#include <gio/gio.h>
+#include <gio/gunixinputstream.h>
+
+#include <fcgiapp.h>
+
+G_BEGIN_DECLS
+
+#define VSGI_FASTCGI_TYPE_INPUT_STREAM (vsgi_fastcgi_input_stream_get_type ())
+G_DECLARE_FINAL_TYPE (VSGIFastCGIInputStream, vsgi_fastcgi_input_stream, VSGI_FASTCGI, INPUT_STREAM, GUnixInputStream)
+
+VSGIFastCGIInputStream * vsgi_fastcgi_input_stream_new (gint fd, FCGX_Stream *in);
+
+G_END_DECLS
+
+#endif

--- a/src/vsgi/servers/vsgi-fastcgi-internal.vapi
+++ b/src/vsgi/servers/vsgi-fastcgi-internal.vapi
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace VSGI.FastCGI {
 	[CCode (cheader_filename = "vsgi-fastcgi-input-stream.h")]
 	public class InputStream : GLib.UnixInputStream {

--- a/src/vsgi/servers/vsgi-fastcgi-internal.vapi
+++ b/src/vsgi/servers/vsgi-fastcgi-internal.vapi
@@ -1,0 +1,10 @@
+namespace VSGI.FastCGI {
+	[CCode (cheader_filename = "vsgi-fastcgi-input-stream.h")]
+	public class InputStream : GLib.UnixInputStream {
+		public InputStream (int fd, global::FastCGI.Stream @in);
+	}
+	[CCode (cheader_filename = "vsgi-fastcgi-output-stream.h")]
+	public class OutputStream : GLib.UnixOutputStream {
+		public OutputStream (int fd, global::FastCGI.Stream @out, global::FastCGI.Stream err);
+	}
+}

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.c
@@ -1,0 +1,161 @@
+#include "vsgi-fastcgi.h"
+#include "vsgi-fastcgi-output-stream.h"
+
+typedef struct
+{
+	FCGX_Stream *out;
+	FCGX_Stream *err;
+} VSGIFastCGIOutputStreamPrivate;
+
+struct _VSGIFastCGIOutputStream
+{
+	GUnixOutputStream               parent_instance;
+	VSGIFastCGIOutputStreamPrivate *priv;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (VSGIFastCGIOutputStream,
+                            vsgi_fastcgi_output_stream,
+                            G_TYPE_UNIX_OUTPUT_STREAM)
+
+static gssize
+vsgi_fastcgi_output_stream_real_write (GOutputStream  *self,
+                                       const void     *buffer,
+                                       gsize           count,
+                                       GCancellable   *cancellable,
+                                       GError        **error)
+{
+	FCGX_Stream *out_stream;
+	gint err;
+	gint ret;
+
+	g_return_val_if_fail (VSGI_FASTCGI_IS_OUTPUT_STREAM (self), -1);
+
+	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
+
+	ret = FCGX_PutStr (buffer, count, out_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (out_stream);
+
+		g_set_error (error,
+		             G_IO_ERROR,
+		             g_io_error_from_errno (err),
+		             vsgi_fastcgi_strerror (err));
+
+		FCGX_ClearError (out_stream);
+
+		return -1;
+	}
+
+	return ret;
+}
+
+static gboolean
+vsgi_fastcgi_output_stream_real_flush (GOutputStream  *self,
+                                       GCancellable   *cancellable,
+                                       GError        **error)
+{
+	FCGX_Stream *out_stream;
+	gint ret;
+	gint err;
+
+	g_return_val_if_fail (VSGI_FASTCGI_IS_OUTPUT_STREAM (self), FALSE);
+
+	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
+
+	ret = FCGX_FFlush (out_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (out_stream);
+
+		g_set_error (error,
+		             G_IO_ERROR,
+		             g_io_error_from_errno (err),
+		             vsgi_fastcgi_strerror (err));
+
+		FCGX_ClearError (out_stream);
+
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+vsgi_fastcgi_output_stream_real_close (GOutputStream  *self,
+                                       GCancellable   *cancellable,
+                                       GError        **error)
+{
+	FCGX_Stream *err_stream;
+	FCGX_Stream *out_stream;
+	gint ret;
+	gint err;
+
+	g_return_val_if_fail (VSGI_FASTCGI_IS_OUTPUT_STREAM (self), FALSE);
+
+	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
+	err_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->err;
+
+	/* always close the error stream first */
+
+	ret = FCGX_FClose (err_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (err_stream);
+
+		/* only emit a critical as we can still recover after */
+		g_critical ("%s (%s, %d)", vsgi_fastcgi_strerror (err),
+		                           g_quark_to_string (G_IO_ERROR),
+		                           g_io_error_from_errno (err));
+
+		FCGX_ClearError (err_stream);
+	}
+
+	ret = FCGX_FClose (out_stream);
+
+	if (G_UNLIKELY (ret == -1))
+	{
+		err = FCGX_GetError (out_stream);
+
+		g_set_error (error,
+		             G_IO_ERROR,
+		             g_io_error_from_errno (err),
+		             vsgi_fastcgi_strerror (err));
+
+		FCGX_ClearError (out_stream);
+
+		return FALSE;
+	}
+
+	return out_stream->isClosed;
+}
+
+static void
+vsgi_fastcgi_output_stream_init (VSGIFastCGIOutputStream *self)
+{
+	self->priv = vsgi_fastcgi_output_stream_get_instance_private (self);
+}
+
+static void
+vsgi_fastcgi_output_stream_class_init (VSGIFastCGIOutputStreamClass *klass)
+{
+	klass->parent_class.parent_class.write_fn = vsgi_fastcgi_output_stream_real_write;
+	klass->parent_class.parent_class.flush    = vsgi_fastcgi_output_stream_real_flush;
+	klass->parent_class.parent_class.close_fn = vsgi_fastcgi_output_stream_real_close;
+}
+
+VSGIFastCGIOutputStream*
+vsgi_fastcgi_output_stream_new (gint fd, FCGX_Stream* out, FCGX_Stream* err)
+{
+	VSGIFastCGIOutputStream *self;
+
+	self = g_object_new (VSGI_FASTCGI_TYPE_OUTPUT_STREAM, "fd", fd, NULL);
+
+	self->priv->out = out;
+	self->priv->err = err;
+
+	return self;
+}

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.c
@@ -32,6 +32,11 @@ vsgi_fastcgi_output_stream_real_write (GOutputStream  *self,
 
 	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
 
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return -1;
+	}
+
 	ret = FCGX_PutStr (buffer, count, out_stream);
 
 	if (G_UNLIKELY (ret == -1))
@@ -63,6 +68,11 @@ vsgi_fastcgi_output_stream_real_flush (GOutputStream  *self,
 	g_return_val_if_fail (VSGI_FASTCGI_IS_OUTPUT_STREAM (self), FALSE);
 
 	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
+
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return FALSE;
+	}
 
 	ret = FCGX_FFlush (out_stream);
 
@@ -98,6 +108,11 @@ vsgi_fastcgi_output_stream_real_close (GOutputStream  *self,
 	out_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->out;
 	err_stream = VSGI_FASTCGI_OUTPUT_STREAM (self)->priv->err;
 
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return FALSE;
+	}
+
 	/* always close the error stream first */
 
 	ret = FCGX_FClose (err_stream);
@@ -112,6 +127,11 @@ vsgi_fastcgi_output_stream_real_close (GOutputStream  *self,
 		                           g_io_error_from_errno (err));
 
 		FCGX_ClearError (err_stream);
+	}
+
+	if (g_cancellable_set_error_if_cancelled (cancellable, error))
+	{
+		return FALSE;
 	}
 
 	ret = FCGX_FClose (out_stream);

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.c
@@ -1,4 +1,3 @@
-#include "vsgi-fastcgi.h"
 #include "vsgi-fastcgi-output-stream.h"
 
 typedef struct
@@ -16,6 +15,31 @@ struct _VSGIFastCGIOutputStream
 G_DEFINE_TYPE_WITH_PRIVATE (VSGIFastCGIOutputStream,
                             vsgi_fastcgi_output_stream,
                             G_TYPE_UNIX_OUTPUT_STREAM)
+
+static const gchar *
+vsgi_fastcgi_strerror (int err)
+{
+	if (err > 0)
+	{
+		return g_strerror (err);
+	}
+	else
+	{
+		switch (err)
+		{
+			case FCGX_CALL_SEQ_ERROR:
+				return "FCXG: Call seq error";
+			case FCGX_PARAMS_ERROR:
+				return "FCGX: Params error";
+			case FCGX_PROTOCOL_ERROR:
+				return "FCGX: Protocol error";
+			case FCGX_UNSUPPORTED_VERSION:
+				return "FCGX: Unsupported version";
+			default:
+				g_assert_not_reached ();
+		}
+	}
+}
 
 static gssize
 vsgi_fastcgi_output_stream_real_write (GOutputStream  *self,

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.c
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "vsgi-fastcgi-output-stream.h"
 
 typedef struct

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.h
@@ -1,0 +1,18 @@
+#ifndef __VSGI_FASTCGI_OUTPUT_STREAM_H__
+#define __VSGI_FASTCGI_OUTPUT_STREAM_H__
+
+#include <gio/gio.h>
+#include <gio/gunixoutputstream.h>
+
+#include <fcgiapp.h>
+
+G_BEGIN_DECLS
+
+#define VSGI_FASTCGI_TYPE_OUTPUT_STREAM (vsgi_fastcgi_output_stream_get_type ())
+G_DECLARE_FINAL_TYPE (VSGIFastCGIOutputStream, vsgi_fastcgi_output_stream, VSGI_FASTCGI, OUTPUT_STREAM, GUnixOutputStream)
+
+VSGIFastCGIOutputStream * vsgi_fastcgi_output_stream_new (gint fd, FCGX_Stream *out, FCGX_Stream *err);
+
+G_END_DECLS
+
+#endif

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef __VSGI_FASTCGI_OUTPUT_STREAM_H__
 #define __VSGI_FASTCGI_OUTPUT_STREAM_H__
 

--- a/src/vsgi/servers/vsgi-fastcgi-output-stream.h
+++ b/src/vsgi/servers/vsgi-fastcgi-output-stream.h
@@ -26,7 +26,18 @@
 G_BEGIN_DECLS
 
 #define VSGI_FASTCGI_TYPE_OUTPUT_STREAM (vsgi_fastcgi_output_stream_get_type ())
-G_DECLARE_FINAL_TYPE (VSGIFastCGIOutputStream, vsgi_fastcgi_output_stream, VSGI_FASTCGI, OUTPUT_STREAM, GUnixOutputStream)
+
+GType vsgi_fastcgi_input_stream_get_type (void);
+
+typedef struct _VSGIFastCGIOutputStream VSGIFastCGIOutputStream;
+
+typedef struct {
+    GUnixOutputStreamClass parent_class;
+} VSGIFastCGIOutputStreamClass;
+
+#define VSGI_FASTCGI_OUTPUT_STREAM(ptr) G_TYPE_CHECK_INSTANCE_CAST (ptr, vsgi_fastcgi_output_stream_get_type (), VSGIFastCGIOutputStream)
+
+#define VSGI_FASTCGI_IS_OUTPUT_STREAM(ptr) G_TYPE_CHECK_INSTANCE_TYPE (ptr, vsgi_fastcgi_output_stream_get_type ())
 
 VSGIFastCGIOutputStream * vsgi_fastcgi_output_stream_new (gint fd, FCGX_Stream *out, FCGX_Stream *err);
 

--- a/src/vsgi/servers/vsgi-fastcgi.vala
+++ b/src/vsgi/servers/vsgi-fastcgi.vala
@@ -31,27 +31,6 @@ public Type server_init (TypeModule type_module) {
 [CCode (lower_case_cprefix = "vsgi_fastcgi_")]
 namespace VSGI.FastCGI {
 
-	/**
-	 * Produce a significant error message given an error on a
-	 * {@link FastCGI.Stream}.
-	 */
-	public string strerror (int error) {
-		if (error > 0) {
-			return GLib.strerror (error);
-		}
-		switch (error) {
-			case global::FastCGI.CALL_SEQ_ERROR:
-				return "FCXG: Call seq error";
-			case global::FastCGI.PARAMS_ERROR:
-				return "FCGX: Params error";
-			case global::FastCGI.PROTOCOL_ERROR:
-				return "FCGX: Protocol error";
-			case global::FastCGI.UNSUPPORTED_VERSION:
-				return "FCGX: Unsupported version";
-		}
-		return "Unknown error code '%d'".printf (error);
-	}
-
 	private errordomain RequestError {
 		FAILED
 	}

--- a/src/vsgi/servers/vsgi-fastcgi.vala
+++ b/src/vsgi/servers/vsgi-fastcgi.vala
@@ -28,13 +28,14 @@ public Type server_init (TypeModule type_module) {
 /**
  * FastCGI implementation of VSGI.
  */
+[CCode (lower_case_cprefix = "vsgi_fastcgi_")]
 namespace VSGI.FastCGI {
 
 	/**
 	 * Produce a significant error message given an error on a
 	 * {@link FastCGI.Stream}.
 	 */
-	private string strerror (int error) {
+	public string strerror (int error) {
 		if (error > 0) {
 			return GLib.strerror (error);
 		}
@@ -49,88 +50,6 @@ namespace VSGI.FastCGI {
 				return "FCGX: Unsupported version";
 		}
 		return "Unknown error code '%d'".printf (error);
-	}
-
-	private class StreamInputStream : UnixInputStream {
-
-		public unowned global::FastCGI.Stream @in { construct; get; }
-
-		public StreamInputStream (int fd, global::FastCGI.Stream @in) {
-			Object (fd: fd, close_fd: false, @in: @in);
-		}
-
-		public override ssize_t read (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
-			var read = this.in.read (buffer);
-
-			if (unlikely (read == GLib.FileStream.EOF)) {
-				critical (strerror (this.in.get_error ()));
-				this.in.clear_error ();
-				return -1;
-			}
-
-			return read;
-		}
-
-		public override bool close (Cancellable? cancellable = null) throws IOError {
-			if (unlikely (in.close () == GLib.FileStream.EOF)) {
-				critical (strerror (this.in.get_error ()));
-				this.in.clear_error ();
-			}
-			return in.is_closed;
-		}
-	}
-
-	private class StreamOutputStream : UnixOutputStream {
-
-		public unowned global::FastCGI.Stream @out { construct; get; }
-
-		public unowned global::FastCGI.Stream err { construct; get; }
-
-		public StreamOutputStream (int fd, global::FastCGI.Stream @out, global::FastCGI.Stream err) {
-			Object (fd: fd, close_fd: false, @out: @out, err: err);
-		}
-
-		public override ssize_t write (uint8[] buffer, Cancellable? cancellable = null) throws IOError {
-			var written = this.out.put_str (buffer);
-
-			if (unlikely (written == GLib.FileStream.EOF)) {
-				critical (strerror (this.out.get_error ()));
-				this.out.clear_error ();
-				return -1;
-			}
-
-			return written;
-		}
-
-		/**
-		 * Headers are written on the first flush call.
-		 */
-		public override bool flush (Cancellable? cancellable = null) {
-			if (unlikely (this.out.flush () == GLib.FileStream.EOF)) {
-				critical (strerror (this.out.get_error ()));
-				this.out.clear_error ();
-				return false;
-			}
-
-			return true;
-		}
-
-		/**
-		 * The 'err' stream is closed before 'out' to avoid an extra write.
-		 */
-		public override bool close (Cancellable? cancellable = null) throws IOError {
-			if (unlikely (this.err.close () == GLib.FileStream.EOF)) {
-				critical (strerror (this.err.get_error ()));
-				this.err.clear_error ();
-			}
-
-			if (unlikely (this.out.close () == GLib.FileStream.EOF)) {
-				critical (strerror (this.out.get_error ()));
-				this.out.clear_error ();
-			}
-
-			return this.out.is_closed;
-		}
 	}
 
 	private errordomain RequestError {
@@ -244,16 +163,16 @@ namespace VSGI.FastCGI {
 
 			public global::FastCGI.request request;
 
-			private StreamInputStream _input_stream;
-			private StreamOutputStream _output_stream;
+			private InputStream _input_stream;
+			private OutputStream _output_stream;
 
-			public override InputStream input_stream {
+			public override GLib.InputStream input_stream {
 				get {
 					return _input_stream;
 				}
 			}
 
-			public override OutputStream output_stream {
+			public override GLib.OutputStream output_stream {
 				get {
 					return this._output_stream;
 				}
@@ -287,8 +206,8 @@ namespace VSGI.FastCGI {
 
 				yield;
 
-				this._input_stream  = new StreamInputStream (fd, request.in);
-				this._output_stream = new StreamOutputStream (fd, request.out, request.err);
+				_input_stream  = new InputStream (fd, request.in);
+				_output_stream = new OutputStream (fd, request.out, request.err);
 
 				return true;
 			}


### PR DESCRIPTION
The current implementation has non-existent error handling due to missing return-value-on-error semantic in Vala.