### PR TITLE
updated all gir_version attributes to 0.4

### DIFF
--- a/src/valum/valum-content-negotiation.vala
+++ b/src/valum/valum-content-negotiation.vala
@@ -21,7 +21,7 @@ using VSGI;
 /**
  * Content negociation for various headers.
  */
-[CCode (gir_namespace = "Valum", gir_version = "0.3")]
+[CCode (gir_namespace = "Valum", gir_version = "0.4")]
 namespace Valum.ContentNegotiation {
 
 	private double _qvalue_for_param (string header, string param) {

--- a/src/valum/valum-server-sent-events.vala
+++ b/src/valum/valum-server-sent-events.vala
@@ -22,7 +22,7 @@ using VSGI;
 /**
  * Middleware and utilities to produce server-sent events.
  */
-[CCode (gir_namespace = "Valum", gir_version = "0.3")]
+[CCode (gir_namespace = "Valum", gir_version = "0.4")]
 namespace Valum.ServerSentEvents {
 
 	/**

--- a/src/valum/valum-static.vala
+++ b/src/valum/valum-static.vala
@@ -21,7 +21,7 @@ using VSGI;
 /**
  * Utilities to serve static resources.
  */
-[CCode (gir_namespace = "Valum", gir_version = "0.3")]
+[CCode (gir_namespace = "Valum", gir_version = "0.4")]
 namespace Valum.Static {
 
 	/**

--- a/src/vsgi/vsgi-cookie-utils.vala
+++ b/src/vsgi/vsgi-cookie-utils.vala
@@ -20,7 +20,7 @@ using Soup;
 /**
  * Cookie-related utilities.
  */
-[CCode (gir_namespace = "VSGI", gir_version = "0.3")]
+[CCode (gir_namespace = "VSGI", gir_version = "0.4")]
 namespace VSGI.CookieUtils {
 
 	/**


### PR DESCRIPTION
This brings all of the generated namespaces to the same version. No Gir or Typelib is generated so it's still not possible to create a Typelib for a library that has Valum public symbols.